### PR TITLE
make docs action running only when new tag is pushed

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,8 +2,6 @@ name: Build and Deploy Documentation
 
 on:
   push:
-    branches:
-      - main  # adjust the branch name if needed
     tags:
       - 'v**'  # specify the pattern for release tags
 


### PR DESCRIPTION
This closes #115.
I had a small discussion with Alessandro and he told me that the `push:` part of the yml file was interpreting the `branches` and `tags` sections with an `or`. After deleting the `branches` it should work, as long as no one creates a tag with the `v**` structure in another branch and this is merged to the main. However, this seems like a very special case.