### PR TITLE
Roch/additional particle info

### DIFF
--- a/docs/source/classes/Particle/index.rst
+++ b/docs/source/classes/Particle/index.rst
@@ -26,3 +26,5 @@ Particle
 .. automethod:: Particle.is_hadron
 .. automethod:: Particle.is_strange
 .. automethod:: Particle.is_heavy_flavor
+.. automethod:: Particle.j_spin
+.. automethod:: Particle.J_spin

--- a/docs/source/classes/Particle/index.rst
+++ b/docs/source/classes/Particle/index.rst
@@ -26,5 +26,5 @@ Particle
 .. automethod:: Particle.is_hadron
 .. automethod:: Particle.is_strange
 .. automethod:: Particle.is_heavy_flavor
-.. automethod:: Particle.j_spin
-.. automethod:: Particle.J_spin
+.. automethod:: Particle.spin
+.. automethod:: Particle.spin_degeneracy

--- a/src/sparkx/Particle.py
+++ b/src/sparkx/Particle.py
@@ -1056,7 +1056,18 @@ class Particle:
             return True
         else:
             return False
-        
+     
+     def spin(self):
+        """
+        Get the total spin :math:`J` of the particle.
+
+        Returns
+        -------
+        float
+            Total spin :math:`J`
+        """
+        return PDGID(self.pdg).J
+           
     def spin_degeneracy(self):
         """
         Get the number of all possible spin projections (:math:`2J + 1`).
@@ -1068,13 +1079,3 @@ class Particle:
         """
         return PDGID(self.pdg).j_spin
     
-    def spin(self):
-        """
-        Get the total spin :math:`J` of the particle.
-
-        Returns
-        -------
-        float
-            Total spin :math:`J`
-        """
-        return PDGID(self.pdg).J

--- a/src/sparkx/Particle.py
+++ b/src/sparkx/Particle.py
@@ -147,6 +147,10 @@ class Particle:
         Is the particle a heavy flavor particle?
     weight:
         What is the weight of the particle?
+    j_spin:
+        Total spin :math:`2J + 1` of the particle.
+    J_spin:
+        Total spin :math:`J` of the particle.
 
     Notes
     -----
@@ -1051,3 +1055,25 @@ class Particle:
             return True
         else:
             return False
+        
+    def j_spin(self):
+        """
+        Get the total spin of the particle (:math:`2J + 1`).
+
+        Returns
+        -------
+        int
+            Total spin :math:`2J + 1`
+        """
+        return PDGID(self.pdg).j_spin
+    
+    def J_spin(self):
+        """
+        Get the total spin :math:`J` of the particle.
+
+        Returns
+        -------
+        float
+            Total spin :math:`J`
+        """
+        return PDGID(self.pdg).J

--- a/src/sparkx/Particle.py
+++ b/src/sparkx/Particle.py
@@ -147,10 +147,11 @@ class Particle:
         Is the particle a heavy flavor particle?
     weight:
         What is the weight of the particle?
-    j_spin:
-        Total spin :math:`2J + 1` of the particle.
-    J_spin:
+    spin:
         Total spin :math:`J` of the particle.
+    spin_degeneracy:
+        Total spin :math:`2J + 1` of the particle.
+    
 
     Notes
     -----
@@ -1056,18 +1057,18 @@ class Particle:
         else:
             return False
         
-    def j_spin(self):
+    def spin_degeneracy(self):
         """
-        Get the total spin of the particle (:math:`2J + 1`).
+        Get the number of all possible spin projections (:math:`2J + 1`).
 
         Returns
         -------
         int
-            Total spin :math:`2J + 1`
+            Spin degeneracy :math:`2J + 1`
         """
         return PDGID(self.pdg).j_spin
     
-    def J_spin(self):
+    def spin(self):
         """
         Get the total spin :math:`J` of the particle.
 


### PR DESCRIPTION
This adds two new functions from the PDGID class to the Particle class. Now we can access the spin as $2J+1$ (integer) or the $J$ itself as a float. At least for all the particles in the database of the external package.