### PR TITLE
Strangeness handling for density smearing

### DIFF
--- a/docs/source/classes/EventCharacteristics/index.rst
+++ b/docs/source/classes/EventCharacteristics/index.rst
@@ -8,3 +8,5 @@ EventCharacteristics
 
 .. automethod:: EventCharacteristics.set_event_data
 .. automethod:: EventCharacteristics.eccentricity
+.. automethod:: EventCharacteristics.generate_eBQS_densities_Milne_from_OSCAR_IC
+.. automethod:: EventCharacteristics.generate_eBQS_densities_Minkowski_from_OSCAR_IC

--- a/src/sparkx/Lattice3D.py
+++ b/src/sparkx/Lattice3D.py
@@ -1065,7 +1065,7 @@ class Lattice3D:
             elif quantity == "baryon_density":
                 value = particle.baryon_number
             elif quantity == "strangeness_density":
-                value = 1 if particle.is_strange() else 0
+                value = particle.strangeness
             else:
                 raise ValueError("Unknown quantity for lattice.");
 

--- a/src/sparkx/Oscar.py
+++ b/src/sparkx/Oscar.py
@@ -313,6 +313,8 @@ class Oscar:
             if self.oscar_format_ != 'Oscar2013Extended_Photons':
                 if particle.baryon_number != None:
                     particle_list.append(int(particle.baryon_number))
+                if particle.strangeness != None:
+                    particle_list.append(int(particle.strangeness))
             else:
                 if particle.weight != None:
                     particle_list.append(int(particle.weight))

--- a/src/sparkx/Particle.py
+++ b/src/sparkx/Particle.py
@@ -56,6 +56,8 @@ class Particle:
         Status code of the particle.
     baryon_number_ : int
         Baryon number of the particle.
+    strangeness_ : int
+        Strangeness quantum number of the particle.
     weight_ : float
         Weight of the particle.
 
@@ -105,6 +107,8 @@ class Particle:
         Get/set status
     baryon_number:
         Get/set baryon_number
+    strangeness:
+        Get/set strangeness
     print_particle:
         Print the particle as CSV to terminal
     set_quantities_OSCAR2013:
@@ -194,6 +198,7 @@ class Particle:
         self.pdg_mother2_ = None
         self.status_ = None
         self.baryon_number_ = None
+        self.strangeness_ = None
         self.weight_ = None
 
     @property
@@ -685,6 +690,28 @@ class Particle:
         self.baryon_number_ = value
 
     @property
+    def strangeness(self):
+        """Get the strangeness of the particle.
+
+        Returns
+        -------
+        strangeness_ : int
+
+        Raises
+        ------
+        ValueError
+            if strangeness is not set
+        """
+        if self.strangeness_ == None:
+            raise ValueError("strangeness not set")
+        else:
+            return self.strangeness_
+
+    @strangeness.setter
+    def strangeness(self,value):
+        self.strangeness_ = value
+
+    @property
     def weight(self):
         """Get the weight of the particle.
 
@@ -774,7 +801,7 @@ class Particle:
         """
         # check if the line is a list or numpy array
         if (type(line_from_file) == list or isinstance(line_from_file, np.ndarray))\
-              and len(line_from_file)<=21 and len(line_from_file)>=20:
+              and len(line_from_file)<=22 and len(line_from_file)>=20:
             self.t = float(line_from_file[0])
             self.x = float(line_from_file[1])
             self.y = float(line_from_file[2])
@@ -795,8 +822,9 @@ class Particle:
             self.t_last_coll = float(line_from_file[17])
             self.pdg_mother1 = int(line_from_file[18])
             self.pdg_mother2 = int(line_from_file[19])
-            if len(line_from_file)==21 and not photon:
+            if len(line_from_file)==22 and not photon:
                 self.baryon_number = int(line_from_file[20])
+                self.strangeness = int(line_from_file[21])
             elif len(line_from_file)==21 and photon:
                 self.weight = float(line_from_file[20])
         else:


### PR DESCRIPTION
This implements the new Oscar2013Extended output format to SPARKX with the strangeness contained in the last column.
We need this for the density smearing, therefore it will be merged to the smearing branch first.

I've tested the Oscar read in with the new test files generated with SMASH.