### PR TITLE
Add option to import SPARKX with *

### DIFF
--- a/src/sparkx/__init__.py
+++ b/src/sparkx/__init__.py
@@ -1,1 +1,12 @@
- 
+from .EventCharacteristics import EventCharacteristics
+from .flow.ReactionPlaneFlow import ReactionPlaneFlow
+from .flow.EventPlaneFlow import EventPlaneFlow
+from .flow.ScalarProductFlow import ScalarProductFlow
+from .flow.GenerateFlow import GenerateFlow
+from .Histogram import Histogram
+from .JetAnalysis import JetAnalysis
+from .Jetscape import Jetscape
+from .Lattice3D import Lattice3D
+from .Oscar import Oscar
+from .Particle import Particle
+from .Utilities import pdg_to_latex

--- a/src/sparkx/flow/__init__.py
+++ b/src/sparkx/flow/__init__.py
@@ -1,1 +1,4 @@
- 
+from sparkx.flow.ReactionPlaneFlow import ReactionPlaneFlow
+from sparkx.flow.EventPlaneFlow import EventPlaneFlow
+from sparkx.flow.ScalarProductFlow import ScalarProductFlow
+from sparkx.flow.GenerateFlow import GenerateFlow


### PR DESCRIPTION
This PR adds the possibility to import the package with `from sparkx import *`.

This closes #129 