### PR TITLE
Change default return of particles to None if quantity is not set

### DIFF
--- a/src/sparkx/Jetscape.py
+++ b/src/sparkx/Jetscape.py
@@ -412,7 +412,7 @@ class Jetscape:
         """
         for i in range(0, self.num_events_):
             self.particle_list_[i] = [elem for elem in self.particle_list_[i]
-                                        if elem.charge != 0]
+                                        if (elem.charge != 0 and elem.charge != None)]
             new_length = len(self.particle_list_[i])
             self.num_output_per_event_[i, 1] = new_length
 
@@ -429,7 +429,7 @@ class Jetscape:
         """
         for i in range(0, self.num_events_):
             self.particle_list_[i] = [elem for elem in self.particle_list_[i]
-                                        if elem.charge == 0]
+                                        if (elem.charge == 0 and elem.charge != None)]
             new_length = len(self.particle_list_[i])
             self.num_output_per_event_[i, 1] = new_length
 
@@ -481,7 +481,7 @@ class Jetscape:
 
             for i in range(0, self.num_events_):
                 self.particle_list_[i] = [elem for elem in self.particle_list_[i]
-                                            if int(elem.pdg) == pdg_list]
+                                            if (int(elem.pdg) == pdg_list and elem.pdg != None)]
                 new_length = len(self.particle_list_[i])
                 self.num_output_per_event_[i, 1] = new_length
 
@@ -491,7 +491,7 @@ class Jetscape:
 
             for i in range(0, self.num_events_):
                 self.particle_list_[i] = [elem for elem in self.particle_list_[i]
-                                            if int(elem.pdg) in pdg_list]
+                                            if (int(elem.pdg) in pdg_list and elem.pdg != None)]
                 new_length = len(self.particle_list_[i])
                 self.num_output_per_event_[i, 1] = new_length
 
@@ -532,7 +532,7 @@ class Jetscape:
 
             for i in range(0, self.num_events_):
                 self.particle_list_[i] = [elem for elem in self.particle_list_[i]
-                                            if int(elem.pdg) != pdg_list]
+                                            if (int(elem.pdg) != pdg_list and elem.pdg != None)]
                 new_length = len(self.particle_list_[i])
                 self.num_output_per_event_[i, 1] = new_length
 
@@ -541,7 +541,7 @@ class Jetscape:
 
             for i in range(0, self.num_events_):
                 self.particle_list_[i] = [elem for elem in self.particle_list_[i]
-                                            if not int(elem.pdg) in pdg_list]
+                                            if (not int(elem.pdg) in pdg_list and elem.pdg != None)]
                 new_length = len(self.particle_list_[i])
                 self.num_output_per_event_[i, 1] = new_length
 
@@ -581,7 +581,7 @@ class Jetscape:
 
             for i in range(0, self.num_events_):
                 self.particle_list_[i] = [elem for elem in self.particle_list_[i]
-                                            if int(elem.status) == status_list]
+                                            if (int(elem.status) == status_list and elem.status != None)]
                 new_length = len(self.particle_list_[i])
                 self.num_output_per_event_[i, 1] = new_length
 
@@ -590,7 +590,7 @@ class Jetscape:
 
             for i in range(0, self.num_events_):
                 self.particle_list_[i] = [elem for elem in self.particle_list_[i]
-                                            if int(elem.status) in status_list]
+                                            if (int(elem.status) in status_list and elem.status != None)]
                 new_length = len(self.particle_list_[i])
                 self.num_output_per_event_[i, 1] = new_length
 
@@ -630,8 +630,7 @@ class Jetscape:
 
         updated_particle_list = []
         for event_particles in self.particle_list_:
-            print(len(event_particles))
-            total_energy = sum(particle.E for particle in event_particles)
+            total_energy = sum(particle.E for particle in event_particles if particle.E != None)
             if total_energy >= minimum_event_energy:
                 updated_particle_list.append(event_particles)
         self.particle_list_ = updated_particle_list
@@ -687,7 +686,7 @@ class Jetscape:
 
         for i in range(0, self.num_events_):
             self.particle_list_[i] = [elem for elem in self.particle_list_[i] if
-                                        lower_cut <= elem.pt_abs() <= upper_cut]
+                                        (lower_cut <= elem.pt_abs() <= upper_cut and elem.pt_abs() != None)]
             new_length = len(self.particle_list_[i])
             self.num_output_per_event_[i, 1] = new_length
 
@@ -736,7 +735,8 @@ class Jetscape:
 
             for i in range(0, self.num_events_):
                 self.particle_list_[i] = [elem for elem in self.particle_list_[i] if
-                                            -limit<=elem.momentum_rapidity_Y()<=limit]
+                                            (-limit<=elem.momentum_rapidity_Y()<=limit 
+                                             and elem.momentum_rapidity_Y() != None)]
                 new_length = len(self.particle_list_[i])
                 self.num_output_per_event_[i, 1] = new_length
 
@@ -746,7 +746,8 @@ class Jetscape:
 
             for i in range(0, self.num_events_):
                 self.particle_list_[i] = [elem for elem in self.particle_list_[i] if
-                                            lim_min<=elem.momentum_rapidity_Y()<=lim_max]
+                                            (lim_min<=elem.momentum_rapidity_Y()<=lim_max
+                                             and elem.momentum_rapidity_Y() != None)]
                 new_length = len(self.particle_list_[i])
                 self.num_output_per_event_[i, 1] = new_length
 
@@ -797,7 +798,8 @@ class Jetscape:
 
             for i in range(0, self.num_events_):
                 self.particle_list_[i] = [elem for elem in self.particle_list_[i] if
-                                            -limit<=elem.pseudorapidity()<=limit]
+                                            (-limit<=elem.pseudorapidity()<=limit
+                                             and elem.pseudorapidity() != None)]
                 new_length = len(self.particle_list_[i])
                 self.num_output_per_event_[i, 1] = new_length
 
@@ -805,11 +807,19 @@ class Jetscape:
             lim_max = max(cut_value[0], cut_value[1])
             lim_min = min(cut_value[0], cut_value[1])
 
-            for i in range(0, self.num_events_):
-                self.particle_list_[i] = [elem for elem in self.particle_list_[i] if
-                                            lim_min<=elem.pseudorapidity()<=lim_max]
-                new_length = len(self.particle_list_[i])
-                self.num_output_per_event_[i, 1] = new_length
+            if self.num_events_ == 1:
+                self.particle_list_ = [elem for elem in self.particle_list_ if
+                                       (lim_min<=elem.pseudorapidity()<=lim_max
+                                        and elem.pseudorapidity() != None)]
+                new_length = len(self.particle_list_)
+                self.num_output_per_event_[1] = new_length
+            else:
+                for i in range(0, self.num_events_):
+                    self.particle_list_[i] = [elem for elem in self.particle_list_[i] if
+                                              (lim_min<=elem.pseudorapidity()<=lim_max
+                                                and elem.pseudorapidity() != None)]
+                    new_length = len(self.particle_list_[i])
+                    self.num_output_per_event_[i, 1] = new_length
 
         else:
             raise TypeError('Input value must be a number or a tuple ' +\

--- a/src/sparkx/Oscar.py
+++ b/src/sparkx/Oscar.py
@@ -581,7 +581,7 @@ class Oscar:
 
         for i in range(0, self.num_events_):
             self.particle_list_[i] = [elem for elem in self.particle_list_[i]
-                                        if elem.charge != 0]
+                                        if (elem.charge != 0 and elem.charge != None)]
             new_length = len(self.particle_list_[i])
             self.num_output_per_event_[i, 1] = new_length
 
@@ -600,7 +600,7 @@ class Oscar:
 
         for i in range(0, self.num_events_):
             self.particle_list_[i] = [elem for elem in self.particle_list_[i]
-                                        if elem.charge == 0]
+                                        if (elem.charge == 0 and elem.charge != None)]
             new_length = len(self.particle_list_[i])
             self.num_output_per_event_[i, 1] = new_length
 
@@ -655,7 +655,7 @@ class Oscar:
             
             for i in range(0, self.num_events_):
                 self.particle_list_[i] = [elem for elem in self.particle_list_[i]
-                                            if int(elem.pdg) == pdg_list]
+                                            if (int(elem.pdg) == pdg_list and elem.pdg != None)]
                 new_length = len(self.particle_list_[i])
                 self.num_output_per_event_[i, 1] = new_length
 
@@ -664,7 +664,7 @@ class Oscar:
 
             for i in range(0, self.num_events_):
                 self.particle_list_[i] = [elem for elem in self.particle_list_[i]
-                                            if int(elem.pdg) in pdg_list]
+                                            if (int(elem.pdg) in pdg_list and elem.pdg != None)]
                 new_length = len(self.particle_list_[i])
                 self.num_output_per_event_[i, 1] = new_length
 
@@ -705,7 +705,7 @@ class Oscar:
 
             for i in range(0, self.num_events_):
                 self.particle_list_[i] = [elem for elem in self.particle_list_[i]
-                                            if int(elem.pdg) != pdg_list]
+                                            if (int(elem.pdg) != pdg_list and elem.pdg != None)]
                 new_length = len(self.particle_list_[i])
                 self.num_output_per_event_[i, 1] = new_length
 
@@ -714,7 +714,7 @@ class Oscar:
 
             for i in range(0, self.num_events_):
                 self.particle_list_[i] = [elem for elem in self.particle_list_[i]
-                                            if not int(elem.pdg) in pdg_list]
+                                            if (not int(elem.pdg) in pdg_list and elem.pdg != None)]
                 new_length = len(self.particle_list_[i])
                 self.num_output_per_event_[i, 1] = new_length
 
@@ -736,7 +736,8 @@ class Oscar:
         """
 
         for i in range(0, self.num_events_):
-            self.particle_list_[i] = [elem for elem in self.particle_list_[i] if elem.ncoll != 0]
+            self.particle_list_[i] = [elem for elem in self.particle_list_[i] 
+                                      if (elem.ncoll != 0 and elem.ncoll != None)]
             new_length = len(self.particle_list_[i])
             self.num_output_per_event_[i, 1] = new_length
 
@@ -756,7 +757,7 @@ class Oscar:
 
         for i in range(0, self.num_events_):
             self.particle_list_[i] = [elem for elem in self.particle_list_[i]
-                                        if elem.ncoll == 0 ]
+                                        if (elem.ncoll == 0 and elem.ncoll != None)]
             new_length = len(self.particle_list_[i])
             self.num_output_per_event_[i, 1] = new_length
 
@@ -792,8 +793,7 @@ class Oscar:
 
         updated_particle_list = []
         for event_particles in self.particle_list_:
-            print(len(event_particles))
-            total_energy = sum(particle.E for particle in event_particles)
+            total_energy = sum(particle.E for particle in event_particles if particle.E != None)
             if total_energy >= minimum_event_energy:
                 updated_particle_list.append(event_particles)
         self.particle_list_ = updated_particle_list
@@ -856,16 +856,16 @@ class Oscar:
         for i in range(0, self.num_events_):
             if (dim == "t"):
                 self.particle_list_[i] = [elem for elem in self.particle_list_[i] if
-                                        lower_cut <= elem.t <= upper_cut]
+                                        (lower_cut <= elem.t <= upper_cut and elem.t != None)]
             elif (dim == "x"):
                 self.particle_list_[i] = [elem for elem in self.particle_list_[i] if
-                                        lower_cut <= elem.x <= upper_cut]
+                                        (lower_cut <= elem.x <= upper_cut and elem.x != None)]
             elif (dim == "y"):
                 self.particle_list_[i] = [elem for elem in self.particle_list_[i] if
-                                        lower_cut <= elem.y <= upper_cut]
+                                        (lower_cut <= elem.y <= upper_cut and elem.y != None)]
             else:
                 self.particle_list_[i] = [elem for elem in self.particle_list_[i] if
-                                        lower_cut <= elem.z <= upper_cut]
+                                        (lower_cut <= elem.z <= upper_cut and elem.z != None)]
             new_length = len(self.particle_list_[i])
             self.num_output_per_event_[i, 1] = new_length
 
@@ -911,7 +911,7 @@ class Oscar:
 
         for i in range(0, self.num_events_):
             self.particle_list_[i] = [elem for elem in self.particle_list_[i] if
-                                        lower_cut <= elem.pt_abs() <= upper_cut]
+                                        (lower_cut <= elem.pt_abs() <= upper_cut and elem.pt_abs() != None)]
             new_length = len(self.particle_list_[i])
             self.num_output_per_event_[i, 1] = new_length
 
@@ -958,7 +958,8 @@ class Oscar:
 
             for i in range(0, self.num_events_):
                 self.particle_list_[i] = [elem for elem in self.particle_list_[i] if
-                                            -limit<=elem.momentum_rapidity_Y()<=limit]
+                                            (-limit<=elem.momentum_rapidity_Y()<=limit 
+                                             and elem.momentum_rapidity_Y() != None)]
                 new_length = len(self.particle_list_[i])
                 self.num_output_per_event_[i, 1] = new_length
 
@@ -968,7 +969,8 @@ class Oscar:
 
             for i in range(0, self.num_events_):
                 self.particle_list_[i] = [elem for elem in self.particle_list_[i] if
-                                            lim_min<=elem.momentum_rapidity_Y()<=lim_max]
+                                            (-limit<=elem.momentum_rapidity_Y()<=limit 
+                                             and elem.momentum_rapidity_Y() != None)]
                 new_length = len(self.particle_list_[i])
                 self.num_output_per_event_[i, 1] = new_length
 
@@ -1030,13 +1032,15 @@ class Oscar:
 
             if self.num_events_ == 1:
                 self.particle_list_ = [elem for elem in self.particle_list_ if
-                                       lim_min<=elem.pseudorapidity()<=lim_max]
+                                       (lim_min<=elem.pseudorapidity()<=lim_max
+                                        and elem.pseudorapidity() != None)]
                 new_length = len(self.particle_list_)
                 self.num_output_per_event_[1] = new_length
             else:
                 for i in range(0, self.num_events_):
                     self.particle_list_[i] = [elem for elem in self.particle_list_[i] if
-                                              lim_min<=elem.pseudorapidity()<=lim_max]
+                                              (lim_min<=elem.pseudorapidity()<=lim_max
+                                                and elem.pseudorapidity() != None)]
                     new_length = len(self.particle_list_[i])
                     self.num_output_per_event_[i, 1] = new_length
 
@@ -1088,7 +1092,8 @@ class Oscar:
 
             for i in range(0, self.num_events_):
                 self.particle_list_[i] = [elem for elem in self.particle_list_[i] if
-                                            -limit<=elem.spatial_rapidity()<=limit]
+                                            (-limit<=elem.spatial_rapidity()<=limit
+                                             and elem.spatial_rapidity() != None)]
                 new_length = len(self.particle_list_[i])
                 self.num_output_per_event_[i, 1] = new_length
 
@@ -1098,13 +1103,15 @@ class Oscar:
 
             if self.num_events_ == 1:
                 self.particle_list_ = [elem for elem in self.particle_list_ if
-                                       lim_min<=elem.spatial_rapidity()<=lim_max]
+                                       (lim_min<=elem.spatial_rapidity()<=lim_max
+                                        and elem.spatial_rapidity() != None)]
                 new_length = len(self.particle_list_)
                 self.num_output_per_event_[1] = new_length
             else:
                 for i in range(0, self.num_events_):
                     self.particle_list_[i] = [elem for elem in self.particle_list_[i] if
-                                              lim_min<=elem.spatial_rapidity()<=lim_max]
+                                              (lim_min<=elem.spatial_rapidity()<=lim_max
+                                                and elem.spatial_rapidity() != None)]
                     new_length = len(self.particle_list_[i])
                     self.num_output_per_event_[i, 1] = new_length
 

--- a/src/sparkx/Particle.py
+++ b/src/sparkx/Particle.py
@@ -877,7 +877,7 @@ class Particle:
 
         Notes
         -----
-        If the one of the needed particle quantities is not given, then `None`
+        If one of the needed particle quantities is not given, then `None`
         is returned. 
         """
         if (self.x == None) or (self.y == None) or (self.z == None)\
@@ -899,7 +899,7 @@ class Particle:
         
         Notes
         -----
-        If the one of the needed particle quantities is not given, then `None`
+        If one of the needed particle quantities is not given, then `None`
         is returned.
         """
         if (self.E == None) or (self.pz == None):
@@ -923,7 +923,7 @@ class Particle:
         
         Notes
         -----
-        If the one of the needed particle quantities is not given, then `None`
+        If one of the needed particle quantities is not given, then `None`
         is returned.
         """
         if (self.px == None) or (self.py == None) or (self.pz == None):
@@ -942,7 +942,7 @@ class Particle:
         
         Notes
         -----
-        If the one of the needed particle quantities is not given, then `None`
+        If one of the needed particle quantities is not given, then `None`
         is returned.
         """
         if (self.px == None) or (self.py == None):
@@ -961,7 +961,7 @@ class Particle:
 
         Notes
         -----
-        If the one of the needed particle quantities is not given, then `None`
+        If one of the needed particle quantities is not given, then `None`
         is returned.
         """
         if (self.px == None) or (self.py == None):
@@ -983,7 +983,7 @@ class Particle:
 
         Notes
         -----
-        If the one of the needed particle quantities is not given, then `None`
+        If one of the needed particle quantities is not given, then `None`
         is returned.
         """
         if (self.px == None) or (self.py == None) or (self.pz == None):
@@ -1005,7 +1005,7 @@ class Particle:
 
         Notes
         -----
-        If the one of the needed particle quantities is not given, then `None`
+        If one of the needed particle quantities is not given, then `None`
         is returned.
         """
         if (self.px == None) or (self.py == None) or (self.pz == None):
@@ -1029,7 +1029,7 @@ class Particle:
 
         Notes
         -----
-        If the one of the needed particle quantities is not given, then `None`
+        If one of the needed particle quantities is not given, then `None`
         is returned.
         """
         if (self.t == None) or (self.z == None):
@@ -1051,7 +1051,7 @@ class Particle:
 
         Notes
         -----
-        If the one of the needed particle quantities is not given, then `None`
+        If one of the needed particle quantities is not given, then `None`
         is returned.
         """
         if (self.t == None) or (self.z == None):
@@ -1073,7 +1073,7 @@ class Particle:
 
         Notes
         -----
-        If the one of the needed particle quantities is not given, then `None`
+        If one of the needed particle quantities is not given, then `None`
         is returned.
         """
         if (self.E == None) or (self.px == None) or (self.py == None) or (self.pz == None):

--- a/src/sparkx/Particle.py
+++ b/src/sparkx/Particle.py
@@ -190,6 +190,11 @@ class Particle:
 
         >>> particle_quantity_JETSCAPE = np.array([0,2114,11,2.01351754,1.30688601,-0.422958786,-0.512249773])
         >>> particle = Particle(input_format="JETSCAPE", particle_array=particle_array_oscar2013)
+
+    Notes
+    -----
+    If a member of the Particle class is not set or a quantity should be computed
+    and the needed member variables are not set, then `None` is returned by default.
     """
     def __init__(self,input_format=None,particle_array=None):
         # OSCAR2013 parameters
@@ -387,16 +392,8 @@ class Particle:
         Returns
         -------
         t_ : float
-
-        Raises
-        ------
-        ValueError
-            if time is not set
         """
-        if self.t_ == None:
-            raise ValueError("t not set")
-        else:
-            return self.t_
+        return self.t_
 
     @t.setter
     def t(self,value):
@@ -409,16 +406,8 @@ class Particle:
         Returns
         -------
         x_ : float
-
-        Raises
-        ------
-        ValueError
-            if x is not set
         """
-        if self.x_ == None:
-            raise ValueError("x not set")
-        else:
-            return self.x_
+        return self.x_
 
     @x.setter
     def x(self,value):
@@ -431,16 +420,8 @@ class Particle:
         Returns
         -------
         y_ : float
-
-        Raises
-        ------
-        ValueError
-            if y is not set
         """
-        if self.y_ == None:
-            raise ValueError("y not set")
-        else:
-            return self.y_
+        return self.y_
 
     @y.setter
     def y(self,value):
@@ -453,16 +434,8 @@ class Particle:
         Returns
         -------
         z_ : float
-
-        Raises
-        ------
-        ValueError
-            if z is not set
         """
-        if self.z_ == None:
-            raise ValueError("z not set")
-        else:
-            return self.z_
+        return self.z_
 
     @z.setter
     def z(self,value):
@@ -475,16 +448,8 @@ class Particle:
         Returns
         -------
         mass_ : float
-
-        Raises
-        ------
-        ValueError
-            if mass is not set
         """
-        if self.mass_ == None:
-            raise ValueError("mass not set")
-        else:
-            return self.mass_
+        return self.mass_
 
     @mass.setter
     def mass(self,value):
@@ -497,16 +462,8 @@ class Particle:
         Returns
         -------
         E_ : float
-
-        Raises
-        ------
-        ValueError
-            if E is not set
         """
-        if self.E_ == None:
-            raise ValueError("E not set")
-        else:
-            return self.E_
+        return self.E_
 
     @E.setter
     def E(self,value):
@@ -519,16 +476,8 @@ class Particle:
         Returns
         -------
         px_ : float
-
-        Raises
-        ------
-        ValueError
-            if px is not set
         """
-        if self.px_ == None:
-            raise ValueError("px not set")
-        else:
-            return self.px_
+        return self.px_
 
     @px.setter
     def px(self,value):
@@ -541,16 +490,8 @@ class Particle:
         Returns
         -------
         py_ : float
-
-        Raises
-        ------
-        ValueError
-            if py is not set
         """
-        if self.py_ == None:
-            raise ValueError("py not set")
-        else:
-            return self.py_
+        return self.py_
 
     @py.setter
     def py(self,value):
@@ -563,16 +504,8 @@ class Particle:
         Returns
         -------
         pz_ : float
-
-        Raises
-        ------
-        ValueError
-            if pz is not set
         """
-        if self.pz_ == None:
-            raise ValueError("pz not set")
-        else:
-            return self.pz_
+        return self.pz_
 
     @pz.setter
     def pz(self,value):
@@ -585,16 +518,8 @@ class Particle:
         Returns
         -------
         pdg_ : int
-
-        Raises
-        ------
-        ValueError
-            if pdg is not set
         """
-        if self.pdg_ == None:
-            raise ValueError("pdg not set")
-        else:
-            return self.pdg_
+        return self.pdg_
 
     @pdg.setter
     def pdg(self,value):
@@ -603,7 +528,7 @@ class Particle:
 
         if(not self.pdg_valid_):
              warnings.warn('The PDG code ' + str(self.pdg_) + ' is not valid. '+
-                           'All properties extracted from the PDG are set to default values.')
+                           'All properties extracted from the PDG are set to None.')
 
     @property
     def ID(self):
@@ -614,16 +539,8 @@ class Particle:
         Returns
         -------
         ID_ : int
-
-        Raises
-        ------
-        ValueError
-            if ID is not set
         """
-        if self.ID_ == None:
-            raise ValueError("ID not set")
-        else:
-            return self.ID_
+        return self.ID_
 
     @ID.setter
     def ID(self,value):
@@ -636,16 +553,8 @@ class Particle:
         Returns
         -------
         charge_ : int
-
-        Raises
-        ------
-        ValueError
-            if charge is not set
         """
-        if self.charge_ == None:
-            raise ValueError("charge not set")
-        else:
-            return self.charge_
+        return self.charge_
 
     @charge.setter
     def charge(self,value):
@@ -658,16 +567,8 @@ class Particle:
         Returns
         -------
         ncoll_ : int
-
-        Raises
-        ------
-        ValueError
-            if ncoll is not set
         """
-        if self.ncoll_ == None:
-            raise ValueError("ncoll not set")
-        else:
-            return self.ncoll_
+        return self.ncoll_
 
     @ncoll.setter
     def ncoll(self,value):
@@ -680,16 +581,8 @@ class Particle:
         Returns
         -------
         form_time_ : float
-
-        Raises
-        ------
-        ValueError
-            if form_time is not set
         """
-        if self.form_time_ == None:
-            raise ValueError("form_time not set")
-        else:
-            return self.form_time_
+        return self.form_time_
 
     @form_time.setter
     def form_time(self,value):
@@ -702,16 +595,8 @@ class Particle:
         Returns
         -------
         xsecfac_ : float
-
-        Raises
-        ------
-        ValueError
-            if xsecfac is not set
         """
-        if self.xsecfac_ == None:
-            raise ValueError("xsecfac not set")
-        else:
-            return self.xsecfac_
+        return self.xsecfac_
 
     @xsecfac.setter
     def xsecfac(self,value):
@@ -724,16 +609,8 @@ class Particle:
         Returns
         -------
         proc_id_origin_ : int
-
-        Raises
-        ------
-        ValueError
-            if proc_id_origin is not set
         """
-        if self.proc_id_origin_ == None:
-            raise ValueError("proc_id_origin not set")
-        else:
-            return self.proc_id_origin_
+        return self.proc_id_origin_
 
     @proc_id_origin.setter
     def proc_id_origin(self,value):
@@ -746,16 +623,8 @@ class Particle:
         Returns
         -------
         proc_type_origin_ : int
-
-        Raises
-        ------
-        ValueError
-            if proc_type_origin is not set
         """
-        if self.proc_type_origin_ == None:
-            raise ValueError("proc_type_origin not set")
-        else:
-            return self.proc_type_origin_
+        return self.proc_type_origin_
 
     @proc_type_origin.setter
     def proc_type_origin(self,value):
@@ -768,16 +637,8 @@ class Particle:
         Returns
         -------
         t_last_coll_ : float
-
-        Raises
-        ------
-        ValueError
-            if t_last_coll is not set
         """
-        if self.t_last_coll_ == None:
-            raise ValueError("t_last_coll not set")
-        else:
-            return self.t_last_coll_
+        return self.t_last_coll_
 
     @t_last_coll.setter
     def t_last_coll(self,value):
@@ -790,16 +651,8 @@ class Particle:
         Returns
         -------
         pdg_mother1_ : int
-
-        Raises
-        ------
-        ValueError
-            if pdg_mother1 is not set
         """
-        if self.pdg_mother1_ == None:
-            raise ValueError("pdg_mother1 not set")
-        else:
-            return self.pdg_mother1_
+        return self.pdg_mother1_
 
     @pdg_mother1.setter
     def pdg_mother1(self,value):
@@ -812,16 +665,8 @@ class Particle:
         Returns
         -------
         pdg_mother2_ : int
-
-        Raises
-        ------
-        ValueError
-            if pdg_mother2 is not set
         """
-        if self.pdg_mother2_ == None:
-            raise ValueError("pdg_mother2 not set")
-        else:
-            return self.pdg_mother2_
+        return self.pdg_mother2_
 
     @pdg_mother2.setter
     def pdg_mother2(self,value):
@@ -836,16 +681,8 @@ class Particle:
         Returns
         -------
         status_ : int
-
-        Raises
-        ------
-        ValueError
-            if status is not set
         """
-        if self.status_ == None:
-            raise ValueError("status not set")
-        else:
-            return self.status_
+        return self.status_
 
     @status.setter
     def status(self,value):
@@ -858,16 +695,8 @@ class Particle:
         Returns
         -------
         baryon_number_ : int
-
-        Raises
-        ------
-        ValueError
-            if baryon_number is not set
         """
-        if self.baryon_number_ == None:
-            raise ValueError("baryon number not set")
-        else:
-            return self.baryon_number_
+        return self.baryon_number_
 
     @baryon_number.setter
     def baryon_number(self,value):
@@ -880,16 +709,8 @@ class Particle:
         Returns
         -------
         strangeness_ : int
-
-        Raises
-        ------
-        ValueError
-            if strangeness is not set
         """
-        if self.strangeness_ == None:
-            raise ValueError("strangeness not set")
-        else:
-            return self.strangeness_
+        return self.strangeness_
 
     @strangeness.setter
     def strangeness(self,value):
@@ -902,16 +723,8 @@ class Particle:
         Returns
         -------
         weight_ : float
-
-        Raises
-        ------
-        ValueError
-            if weight is not set
         """
-        if self.weight_ == None:
-            raise ValueError("weight not set")
-        else:
-            return self.weight_
+        return self.weight_
 
     @weight.setter
     def weight(self,value):
@@ -926,13 +739,13 @@ class Particle:
         """
         print('t,x,y,z,mass,E,px,py,pz,pdg,ID,charge,ncoll,form_time,xsecfac,\
               proc_id_origin,proc_type_origin,t_last_coll,pdg_mother1,\
-              pdg_mother2,status,baryon_number,weight')
+              pdg_mother2,status,baryon_number,strangeness,weight')
         print(f'{self.t_},{self.x_},{self.y_},{self.z_},{self.mass_},{self.E_},\
               {self.px_},{self.py_},{self.pz_},{self.pdg_},{self.ID_},\
               {self.charge_},{self.ncoll_},{self.form_time_},{self.xsecfac_},\
               {self.proc_id_origin_},{self.proc_type_origin_}\
               ,{self.t_last_coll_},{self.pdg_mother1_},{self.pdg_mother2_},\
-              {self.status_},{self.baryon_number_},{self.weight_}')
+              {self.status_},{self.baryon_number_},{self.strangeness_},{self.weight_}')
 
     def set_quantities_OSCAR2013(self,line_from_file):
         """
@@ -1061,11 +874,19 @@ class Particle:
         angular_momentum : numpy.ndarray
             Array containing all three components of the
             angular momentum as :math:`[L_x, L_y, L_z]`.
-        """
-        r = [self.x, self.y, self.z]
-        p = [self.px, self.py, self.pz]
 
-        return np.cross(r, p)
+        Notes
+        -----
+        If the one of the needed particle quantities is not given, then `None`
+        is returned. 
+        """
+        if (self.x == None) or (self.y == None) or (self.z == None)\
+            (self.px == None) or (self.py == None) or (self.pz == None):
+            return None
+        else:
+            r = [self.x, self.y, self.z]
+            p = [self.px, self.py, self.pz]
+            return np.cross(r, p)
 
     def momentum_rapidity_Y(self):
         """
@@ -1075,13 +896,21 @@ class Particle:
         -------
         float
             momentum rapidity
+        
+        Notes
+        -----
+        If the one of the needed particle quantities is not given, then `None`
+        is returned.
         """
-        if abs(self.E - self.pz) < 1e-10:
-            denominator = (self.E - self.pz) + 1e-10  # Adding a small positive value
+        if (self.E == None) or (self.pz == None):
+            return None
         else:
-            denominator = (self.E - self.pz)
+            if abs(self.E - self.pz) < 1e-10:
+                denominator = (self.E - self.pz) + 1e-10  # Adding a small positive value
+            else:
+                denominator = (self.E - self.pz)
 
-        return 0.5 * np.log((self.E + self.pz) / denominator)
+            return 0.5 * np.log((self.E + self.pz) / denominator)
 
     def p_abs(self):
         """
@@ -1091,8 +920,16 @@ class Particle:
         -------
         float
             absolute momentum
+        
+        Notes
+        -----
+        If the one of the needed particle quantities is not given, then `None`
+        is returned.
         """
-        return np.sqrt(self.px**2.+self.py**2.+self.pz**2.)
+        if (self.px == None) or (self.py == None) or (self.pz == None):
+            return None
+        else:
+            return np.sqrt(self.px**2.+self.py**2.+self.pz**2.)
 
     def pt_abs(self):
         """
@@ -1102,8 +939,16 @@ class Particle:
         -------
         float
             absolute transverse momentum
+        
+        Notes
+        -----
+        If the one of the needed particle quantities is not given, then `None`
+        is returned.
         """
-        return np.sqrt(self.px**2.+self.py**2.)
+        if (self.px == None) or (self.py == None):
+            return None
+        else:
+            return np.sqrt(self.px**2.+self.py**2.)
 
     def phi(self):
         """
@@ -1113,11 +958,19 @@ class Particle:
         -------
         float
             azimuthal angle
+
+        Notes
+        -----
+        If the one of the needed particle quantities is not given, then `None`
+        is returned.
         """
-        if (np.abs(self.px) < 1e-6) and (np.abs(self.py) < 1e-6):
-            return 0.
+        if (self.px == None) or (self.py == None):
+            return None
         else:
-            return math.atan2(self.py,self.px)
+            if (np.abs(self.px) < 1e-6) and (np.abs(self.py) < 1e-6):
+                return 0.
+            else:
+                return math.atan2(self.py,self.px)
 
     def theta(self):
         """
@@ -1127,11 +980,19 @@ class Particle:
         -------
         float
             polar angle
+
+        Notes
+        -----
+        If the one of the needed particle quantities is not given, then `None`
+        is returned.
         """
-        if self.p_abs() == 0:
-            return 0.
+        if (self.px == None) or (self.py == None) or (self.pz == None):
+            return None
         else:
-            return np.arccos(self.pz / self.p_abs())
+            if self.p_abs() == 0:
+                return 0.
+            else:
+                return np.arccos(self.pz / self.p_abs())
 
     def pseudorapidity(self):
         """
@@ -1141,13 +1002,21 @@ class Particle:
         -------
         float
             pseudorapidity
-        """
-        if abs(self.p_abs() - self.pz) < 1e-10:
-            denominator = (self.p_abs() - self.pz) + 1e-10  # Adding a small positive value
-        else:
-            denominator = (self.p_abs() - self.pz)
 
-        return 0.5 * np.log((self.p_abs()+self.pz) / denominator)
+        Notes
+        -----
+        If the one of the needed particle quantities is not given, then `None`
+        is returned.
+        """
+        if (self.px == None) or (self.py == None) or (self.pz == None):
+            return None
+        else:
+            if abs(self.p_abs() - self.pz) < 1e-10:
+                denominator = (self.p_abs() - self.pz) + 1e-10  # Adding a small positive value
+            else:
+                denominator = (self.p_abs() - self.pz)
+
+            return 0.5 * np.log((self.p_abs()+self.pz) / denominator)
 
     def spatial_rapidity(self):
         """
@@ -1157,11 +1026,19 @@ class Particle:
         -------
         float
             spatial rapidity
+
+        Notes
+        -----
+        If the one of the needed particle quantities is not given, then `None`
+        is returned.
         """
-        if self.t > np.abs(self.z):
-            return 0.5 * np.log((self.t+self.z) / (self.t-self.z))
+        if (self.t == None) or (self.z == None):
+            return None
         else:
-            raise ValueError("|z| < t not fulfilled")
+            if self.t > np.abs(self.z):
+                return 0.5 * np.log((self.t+self.z) / (self.t-self.z))
+            else:
+                raise ValueError("|z| < t not fulfilled")
 
     def proper_time(self):
         """
@@ -1171,11 +1048,19 @@ class Particle:
         -------
         float
             proper time
+
+        Notes
+        -----
+        If the one of the needed particle quantities is not given, then `None`
+        is returned.
         """
-        if self.t > np.abs(self.z):
-            return np.sqrt(self.t**2.-self.z**2.)
+        if (self.t == None) or (self.z == None):
+            return None
         else:
-            raise ValueError("|z| < t not fulfilled")
+            if self.t > np.abs(self.z):
+                return np.sqrt(self.t**2.-self.z**2.)
+            else:
+                raise ValueError("|z| < t not fulfilled")
 
     def compute_mass_from_energy_momentum(self):
         """
@@ -1185,12 +1070,20 @@ class Particle:
         -------
         float
             mass
+
+        Notes
+        -----
+        If the one of the needed particle quantities is not given, then `None`
+        is returned.
         """
-        if np.abs(self.E**2. - self.p_abs()**2.) > 1e-6 and\
-              self.E**2. - self.p_abs()**2. > 0.:
-            return np.sqrt(self.E**2.-self.p_abs()**2.)
+        if (self.E == None) or (self.px == None) or (self.py == None) or (self.pz == None):
+            return None
         else:
-            return 0.
+            if np.abs(self.E**2. - self.p_abs()**2.) > 1e-6 and\
+                  self.E**2. - self.p_abs()**2. > 0.:
+                return np.sqrt(self.E**2.-self.p_abs()**2.)
+            else:
+                return 0.
 
     def compute_charge_from_pdg(self):
         """
@@ -1203,6 +1096,10 @@ class Particle:
         -------
         float
             charge
+        
+        Notes
+        -----
+        If the PDG ID is not known by `PDGID`, then `None` is returned.
         """
         if not self.pdg_valid_:
             return None
@@ -1216,9 +1113,13 @@ class Particle:
         -------
         bool
             True, False
+
+        Notes
+        -----
+        If the PDG ID is not known by `PDGID`, then `None` is returned.
         """
         if not self.pdg_valid_:
-            return False
+            return None
         return PDGID(self.pdg).is_meson
 
     def is_baryon(self):
@@ -1229,9 +1130,13 @@ class Particle:
         -------
         bool
             True, False
+
+        Notes
+        -----
+        If the PDG ID is not known by `PDGID`, then `None` is returned.
         """
         if not self.pdg_valid_:
-            return False
+            return None
         return PDGID(self.pdg).is_baryon
 
     def is_hadron(self):
@@ -1242,9 +1147,13 @@ class Particle:
         -------
         bool
             True, False
+
+        Notes
+        -----
+        If the PDG ID is not known by `PDGID`, then `None` is returned.
         """
         if not self.pdg_valid_:
-            return False
+            return None
         return PDGID(self.pdg).is_hadron
 
     def is_strange(self):
@@ -1255,9 +1164,13 @@ class Particle:
         -------
         bool
             True, False
+        
+        Notes
+        -----
+        If the PDG ID is not known by `PDGID`, then `None` is returned.
         """
         if not self.pdg_valid_:
-            return False
+            return None
         return PDGID(self.pdg).has_strange
 
     def is_heavy_flavor(self):
@@ -1268,9 +1181,13 @@ class Particle:
         -------
         bool
             True, False
+
+        Notes
+        -----
+        If the PDG ID is not known by `PDGID`, then `None` is returned.
         """
         if not self.pdg_valid_:
-            return False
+            return None
         if PDGID(self.pdg).has_charm or PDGID(self.pdg).has_bottom\
               or PDGID(self.pdg).has_top:
             return True
@@ -1285,6 +1202,10 @@ class Particle:
         -------
         float
             Total spin :math:`J`
+        
+        Notes
+        -----
+        If the PDG ID is not known by `PDGID`, then `None` is returned.
         """
         if not self.pdg_valid_:
             return None
@@ -1298,6 +1219,10 @@ class Particle:
         -------
         int
             Spin degeneracy :math:`2J + 1`
+
+        Notes
+        -----
+        If the PDG ID is not known by `PDGID`, then `None` is returned.
         """
         if not self.pdg_valid_:
             return None


### PR DESCRIPTION
This PR changes the default return from the Particle class to `None` if a member is not set or if a quantity can not be computed from the currently set members.

There is also a bug fix for the non-symmetric pseudorapidity cut in the JETSCAPE class. 

This closes #143 and addresses part of the things that changed in PR #142. Maybe this should be merged after #142.

