### PR TITLE
SPARKX on diet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,8 +45,9 @@ A `Depracted` section could be added if needed for soon-to-be removed features.
 * Oscar/Jetscape: Handling of PDG id's which are not present in the `particle` package is moved to the Particle class
 * Oscar/Jetscape: Improved writing to file
 * Particle: Particle construction is now done within the constructor by providing a format and an array of values
+* Particle: Internal structure is now a numpy float array
 * Particle: Functions using `PDGID` from the `particle` package handle now the case if the PDG ID is unknown to the package
-* Particle: Returns `None` if the quantity is not known or can not be computed
+* Particle: Returns `nan` if the quantity is not known or can not be computed
 
 # Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-The versioning of the codebase is inpired by [Semantic Versioning](https://semver.org/spec/v2.0.0.html) with a version number `X.Y.Z`, where
+The versioning of the codebase is inspired by [Semantic Versioning](https://semver.org/spec/v2.0.0.html) with a version number `X.Y.Z`, where
 
 * `X` is incremented for major changes (e.g. large backwards incompatible updates),
 * `Y` is incremented for minor changes (e.g. external pull-request that adds one feature) and
@@ -16,7 +16,7 @@ The main categories for changes in this file are:
 * `Fixed` for any bug fixes;
 * `Removed` for now removed features.
 
-A `Depracted` section could be added if needed for soon-to-be removed features.
+A `Deprecated` section could be added if needed for soon-to-be removed features.
 
 ## Unreleased
 

--- a/src/sparkx/Jetscape.py
+++ b/src/sparkx/Jetscape.py
@@ -641,7 +641,7 @@ class Jetscape:
             raise TypeError('Input value for lower event energy cut has not ' +\
                             'one of the following types: int, float')
         if minimum_event_energy <= 0.:
-            raise ValueError('The lower event energ cut value should be positive')
+            raise ValueError('The lower event energy cut value should be positive')
 
         updated_particle_list = []
         for event_particles in self.particle_list_:

--- a/src/sparkx/Jetscape.py
+++ b/src/sparkx/Jetscape.py
@@ -461,7 +461,7 @@ class Jetscape:
         """
         for i in range(0, self.num_events_):
             self.particle_list_[i] = [elem for elem in self.particle_list_[i]
-                                        if elem.is_strange()]
+                                        if (elem.strangeness != 0 and elem.strangeness != np.nan)]
             new_length = len(self.particle_list_[i])
             self.num_output_per_event_[i, 1] = new_length
 

--- a/src/sparkx/Jetscape.py
+++ b/src/sparkx/Jetscape.py
@@ -427,7 +427,7 @@ class Jetscape:
         """
         for i in range(0, self.num_events_):
             self.particle_list_[i] = [elem for elem in self.particle_list_[i]
-                                        if (elem.charge != 0 and elem.charge != None)]
+                                        if (elem.charge != 0 and elem.charge != np.nan)]
             new_length = len(self.particle_list_[i])
             self.num_output_per_event_[i, 1] = new_length
 
@@ -444,7 +444,7 @@ class Jetscape:
         """
         for i in range(0, self.num_events_):
             self.particle_list_[i] = [elem for elem in self.particle_list_[i]
-                                        if (elem.charge == 0 and elem.charge != None)]
+                                        if (elem.charge == 0 and elem.charge != np.nan)]
             new_length = len(self.particle_list_[i])
             self.num_output_per_event_[i, 1] = new_length
 
@@ -496,7 +496,7 @@ class Jetscape:
 
             for i in range(0, self.num_events_):
                 self.particle_list_[i] = [elem for elem in self.particle_list_[i]
-                                            if (int(elem.pdg) == pdg_list and elem.pdg != None)]
+                                            if (int(elem.pdg) == pdg_list and elem.pdg != np.nan)]
                 new_length = len(self.particle_list_[i])
                 self.num_output_per_event_[i, 1] = new_length
 
@@ -506,7 +506,7 @@ class Jetscape:
 
             for i in range(0, self.num_events_):
                 self.particle_list_[i] = [elem for elem in self.particle_list_[i]
-                                            if (int(elem.pdg) in pdg_list and elem.pdg != None)]
+                                            if (int(elem.pdg) in pdg_list and elem.pdg != np.nan)]
                 new_length = len(self.particle_list_[i])
                 self.num_output_per_event_[i, 1] = new_length
 
@@ -547,7 +547,7 @@ class Jetscape:
 
             for i in range(0, self.num_events_):
                 self.particle_list_[i] = [elem for elem in self.particle_list_[i]
-                                            if (int(elem.pdg) != pdg_list and elem.pdg != None)]
+                                            if (int(elem.pdg) != pdg_list and elem.pdg != np.nan)]
                 new_length = len(self.particle_list_[i])
                 self.num_output_per_event_[i, 1] = new_length
 
@@ -556,7 +556,7 @@ class Jetscape:
 
             for i in range(0, self.num_events_):
                 self.particle_list_[i] = [elem for elem in self.particle_list_[i]
-                                            if (not int(elem.pdg) in pdg_list and elem.pdg != None)]
+                                            if (not int(elem.pdg) in pdg_list and elem.pdg != np.nan)]
                 new_length = len(self.particle_list_[i])
                 self.num_output_per_event_[i, 1] = new_length
 
@@ -596,7 +596,7 @@ class Jetscape:
 
             for i in range(0, self.num_events_):
                 self.particle_list_[i] = [elem for elem in self.particle_list_[i]
-                                            if (int(elem.status) == status_list and elem.status != None)]
+                                            if (int(elem.status) == status_list and elem.status != np.nan)]
                 new_length = len(self.particle_list_[i])
                 self.num_output_per_event_[i, 1] = new_length
 
@@ -605,7 +605,7 @@ class Jetscape:
 
             for i in range(0, self.num_events_):
                 self.particle_list_[i] = [elem for elem in self.particle_list_[i]
-                                            if (int(elem.status) in status_list and elem.status != None)]
+                                            if (int(elem.status) in status_list and elem.status != np.nan)]
                 new_length = len(self.particle_list_[i])
                 self.num_output_per_event_[i, 1] = new_length
 
@@ -645,7 +645,7 @@ class Jetscape:
 
         updated_particle_list = []
         for event_particles in self.particle_list_:
-            total_energy = sum(particle.E for particle in event_particles if particle.E != None)
+            total_energy = sum(particle.E for particle in event_particles if particle.E != np.nan)
             if total_energy >= minimum_event_energy:
                 updated_particle_list.append(event_particles)
         self.particle_list_ = updated_particle_list
@@ -751,7 +751,7 @@ class Jetscape:
             for i in range(0, self.num_events_):
                 self.particle_list_[i] = [elem for elem in self.particle_list_[i] if
                                             (-limit<=elem.momentum_rapidity_Y()<=limit 
-                                             and elem.momentum_rapidity_Y() != None)]
+                                             and elem.momentum_rapidity_Y() != np.nan)]
                 new_length = len(self.particle_list_[i])
                 self.num_output_per_event_[i, 1] = new_length
 
@@ -762,7 +762,7 @@ class Jetscape:
             for i in range(0, self.num_events_):
                 self.particle_list_[i] = [elem for elem in self.particle_list_[i] if
                                             (lim_min<=elem.momentum_rapidity_Y()<=lim_max
-                                             and elem.momentum_rapidity_Y() != None)]
+                                             and elem.momentum_rapidity_Y() != np.nan)]
                 new_length = len(self.particle_list_[i])
                 self.num_output_per_event_[i, 1] = new_length
 
@@ -814,7 +814,7 @@ class Jetscape:
             for i in range(0, self.num_events_):
                 self.particle_list_[i] = [elem for elem in self.particle_list_[i] if
                                             (-limit<=elem.pseudorapidity()<=limit
-                                             and elem.pseudorapidity() != None)]
+                                             and elem.pseudorapidity() != np.nan)]
                 new_length = len(self.particle_list_[i])
                 self.num_output_per_event_[i, 1] = new_length
 
@@ -825,14 +825,14 @@ class Jetscape:
             if self.num_events_ == 1:
                 self.particle_list_ = [elem for elem in self.particle_list_ if
                                        (lim_min<=elem.pseudorapidity()<=lim_max
-                                        and elem.pseudorapidity() != None)]
+                                        and elem.pseudorapidity() != np.nan)]
                 new_length = len(self.particle_list_)
                 self.num_output_per_event_[1] = new_length
             else:
                 for i in range(0, self.num_events_):
                     self.particle_list_[i] = [elem for elem in self.particle_list_[i] if
                                               (lim_min<=elem.pseudorapidity()<=lim_max
-                                                and elem.pseudorapidity() != None)]
+                                                and elem.pseudorapidity() != np.nan)]
                     new_length = len(self.particle_list_[i])
                     self.num_output_per_event_[i, 1] = new_length
 

--- a/src/sparkx/Oscar.py
+++ b/src/sparkx/Oscar.py
@@ -613,7 +613,7 @@ class Oscar:
 
         for i in range(0, self.num_events_):
             self.particle_list_[i] = [elem for elem in self.particle_list_[i]
-                                        if elem.is_strange()]
+                                        if (elem.strangeness()!=0 and elem.strangeness != np.nan)]
             new_length = len(self.particle_list_[i])
             self.num_output_per_event_[i, 1] = new_length
 

--- a/src/sparkx/Oscar.py
+++ b/src/sparkx/Oscar.py
@@ -307,12 +307,12 @@ class Oscar:
             particle_list.append(int(particle.pdg_mother1))
             particle_list.append(int(particle.pdg_mother2))
             if self.oscar_format_ != 'Oscar2013Extended_Photons':
-                if particle.baryon_number != None:
+                if particle.baryon_number != np.nan:
                     particle_list.append(int(particle.baryon_number))
-                if particle.strangeness != None:
+                if particle.strangeness != np.nan:
                     particle_list.append(int(particle.strangeness))
             else:
-                if particle.weight != None:
+                if particle.weight != np.nan:
                     particle_list.append(int(particle.weight))
 
         elif self.oscar_format_ != 'Oscar2013' and self.oscar_format_ != 'Oscar2013Extended' and self.oscar_format_ != 'Oscar2013Extended_IC' and self.oscar_format_ != 'Oscar2013Extended_Photons':
@@ -575,7 +575,7 @@ class Oscar:
 
         for i in range(0, self.num_events_):
             self.particle_list_[i] = [elem for elem in self.particle_list_[i]
-                                        if (elem.charge != 0 and elem.charge != None)]
+                                        if (elem.charge != 0 and elem.charge != np.nan)]
             new_length = len(self.particle_list_[i])
             self.num_output_per_event_[i, 1] = new_length
 
@@ -594,7 +594,7 @@ class Oscar:
 
         for i in range(0, self.num_events_):
             self.particle_list_[i] = [elem for elem in self.particle_list_[i]
-                                        if (elem.charge == 0 and elem.charge != None)]
+                                        if (elem.charge == 0 and elem.charge != np.nan)]
             new_length = len(self.particle_list_[i])
             self.num_output_per_event_[i, 1] = new_length
 
@@ -649,7 +649,7 @@ class Oscar:
             
             for i in range(0, self.num_events_):
                 self.particle_list_[i] = [elem for elem in self.particle_list_[i]
-                                            if (int(elem.pdg) == pdg_list and elem.pdg != None)]
+                                            if (int(elem.pdg) == pdg_list and elem.pdg != np.nan)]
                 new_length = len(self.particle_list_[i])
                 self.num_output_per_event_[i, 1] = new_length
 
@@ -658,7 +658,7 @@ class Oscar:
 
             for i in range(0, self.num_events_):
                 self.particle_list_[i] = [elem for elem in self.particle_list_[i]
-                                            if (int(elem.pdg) in pdg_list and elem.pdg != None)]
+                                            if (int(elem.pdg) in pdg_list and elem.pdg != np.nan)]
                 new_length = len(self.particle_list_[i])
                 self.num_output_per_event_[i, 1] = new_length
 
@@ -699,7 +699,7 @@ class Oscar:
 
             for i in range(0, self.num_events_):
                 self.particle_list_[i] = [elem for elem in self.particle_list_[i]
-                                            if (int(elem.pdg) != pdg_list and elem.pdg != None)]
+                                            if (int(elem.pdg) != pdg_list and elem.pdg != np.nan)]
                 new_length = len(self.particle_list_[i])
                 self.num_output_per_event_[i, 1] = new_length
 
@@ -708,7 +708,7 @@ class Oscar:
 
             for i in range(0, self.num_events_):
                 self.particle_list_[i] = [elem for elem in self.particle_list_[i]
-                                            if (not int(elem.pdg) in pdg_list and elem.pdg != None)]
+                                            if (not int(elem.pdg) in pdg_list and elem.pdg != np.nan)]
                 new_length = len(self.particle_list_[i])
                 self.num_output_per_event_[i, 1] = new_length
 
@@ -731,7 +731,7 @@ class Oscar:
 
         for i in range(0, self.num_events_):
             self.particle_list_[i] = [elem for elem in self.particle_list_[i] 
-                                      if (elem.ncoll != 0 and elem.ncoll != None)]
+                                      if (elem.ncoll != 0 and elem.ncoll != np.nan)]
             new_length = len(self.particle_list_[i])
             self.num_output_per_event_[i, 1] = new_length
 
@@ -751,7 +751,7 @@ class Oscar:
 
         for i in range(0, self.num_events_):
             self.particle_list_[i] = [elem for elem in self.particle_list_[i]
-                                        if (elem.ncoll == 0 and elem.ncoll != None)]
+                                        if (elem.ncoll == 0 and elem.ncoll != np.nan)]
             new_length = len(self.particle_list_[i])
             self.num_output_per_event_[i, 1] = new_length
 
@@ -783,11 +783,11 @@ class Oscar:
             raise TypeError('Input value for lower event energy cut has not ' +\
                             'one of the following types: int, float')
         if minimum_event_energy <= 0.:
-            raise ValueError('The lower event energ cut value should be positive')
+            raise ValueError('The lower event energy cut value should be positive')
 
         updated_particle_list = []
         for event_particles in self.particle_list_:
-            total_energy = sum(particle.E for particle in event_particles if particle.E != None)
+            total_energy = sum(particle.E for particle in event_particles if particle.E != np.nan)
             if total_energy >= minimum_event_energy:
                 updated_particle_list.append(event_particles)
         self.particle_list_ = updated_particle_list
@@ -850,16 +850,16 @@ class Oscar:
         for i in range(0, self.num_events_):
             if (dim == "t"):
                 self.particle_list_[i] = [elem for elem in self.particle_list_[i] if
-                                        (lower_cut <= elem.t <= upper_cut and elem.t != None)]
+                                        (lower_cut <= elem.t <= upper_cut and elem.t != np.nan)]
             elif (dim == "x"):
                 self.particle_list_[i] = [elem for elem in self.particle_list_[i] if
-                                        (lower_cut <= elem.x <= upper_cut and elem.x != None)]
+                                        (lower_cut <= elem.x <= upper_cut and elem.x != np.nan)]
             elif (dim == "y"):
                 self.particle_list_[i] = [elem for elem in self.particle_list_[i] if
-                                        (lower_cut <= elem.y <= upper_cut and elem.y != None)]
+                                        (lower_cut <= elem.y <= upper_cut and elem.y != np.nan)]
             else:
                 self.particle_list_[i] = [elem for elem in self.particle_list_[i] if
-                                        (lower_cut <= elem.z <= upper_cut and elem.z != None)]
+                                        (lower_cut <= elem.z <= upper_cut and elem.z != np.nan)]
             new_length = len(self.particle_list_[i])
             self.num_output_per_event_[i, 1] = new_length
 
@@ -905,7 +905,7 @@ class Oscar:
 
         for i in range(0, self.num_events_):
             self.particle_list_[i] = [elem for elem in self.particle_list_[i] if
-                                        (lower_cut <= elem.pt_abs() <= upper_cut and elem.pt_abs() != None)]
+                                        (lower_cut <= elem.pt_abs() <= upper_cut and elem.pt_abs() != np.nan)]
             new_length = len(self.particle_list_[i])
             self.num_output_per_event_[i, 1] = new_length
 
@@ -953,7 +953,7 @@ class Oscar:
             for i in range(0, self.num_events_):
                 self.particle_list_[i] = [elem for elem in self.particle_list_[i] if
                                             (-limit<=elem.momentum_rapidity_Y()<=limit 
-                                             and elem.momentum_rapidity_Y() != None)]
+                                             and elem.momentum_rapidity_Y() != np.nan)]
                 new_length = len(self.particle_list_[i])
                 self.num_output_per_event_[i, 1] = new_length
 
@@ -964,7 +964,7 @@ class Oscar:
             for i in range(0, self.num_events_):
                 self.particle_list_[i] = [elem for elem in self.particle_list_[i] if
                                             (-limit<=elem.momentum_rapidity_Y()<=limit 
-                                             and elem.momentum_rapidity_Y() != None)]
+                                             and elem.momentum_rapidity_Y() != np.nan)]
                 new_length = len(self.particle_list_[i])
                 self.num_output_per_event_[i, 1] = new_length
 
@@ -1027,14 +1027,14 @@ class Oscar:
             if self.num_events_ == 1:
                 self.particle_list_ = [elem for elem in self.particle_list_ if
                                        (lim_min<=elem.pseudorapidity()<=lim_max
-                                        and elem.pseudorapidity() != None)]
+                                        and elem.pseudorapidity() != np.nan)]
                 new_length = len(self.particle_list_)
                 self.num_output_per_event_[1] = new_length
             else:
                 for i in range(0, self.num_events_):
                     self.particle_list_[i] = [elem for elem in self.particle_list_[i] if
                                               (lim_min<=elem.pseudorapidity()<=lim_max
-                                                and elem.pseudorapidity() != None)]
+                                                and elem.pseudorapidity() != np.nan)]
                     new_length = len(self.particle_list_[i])
                     self.num_output_per_event_[i, 1] = new_length
 
@@ -1087,7 +1087,7 @@ class Oscar:
             for i in range(0, self.num_events_):
                 self.particle_list_[i] = [elem for elem in self.particle_list_[i] if
                                             (-limit<=elem.spatial_rapidity()<=limit
-                                             and elem.spatial_rapidity() != None)]
+                                             and elem.spatial_rapidity() != np.nan)]
                 new_length = len(self.particle_list_[i])
                 self.num_output_per_event_[i, 1] = new_length
 
@@ -1098,14 +1098,14 @@ class Oscar:
             if self.num_events_ == 1:
                 self.particle_list_ = [elem for elem in self.particle_list_ if
                                        (lim_min<=elem.spatial_rapidity()<=lim_max
-                                        and elem.spatial_rapidity() != None)]
+                                        and elem.spatial_rapidity() != np.nan)]
                 new_length = len(self.particle_list_)
                 self.num_output_per_event_[1] = new_length
             else:
                 for i in range(0, self.num_events_):
                     self.particle_list_[i] = [elem for elem in self.particle_list_[i] if
                                               (lim_min<=elem.spatial_rapidity()<=lim_max
-                                                and elem.spatial_rapidity() != None)]
+                                                and elem.spatial_rapidity() != np.nan)]
                     new_length = len(self.particle_list_[i])
                     self.num_output_per_event_[i, 1] = new_length
 

--- a/src/sparkx/Particle.py
+++ b/src/sparkx/Particle.py
@@ -8,10 +8,10 @@ class Particle:
 
     The member variables of the Particle class are the quantities in the
     OSCAR2013/OSCAR2013Extended or JETSCAPE hadron output. If they are not set,
-    they stay None to throw an error if one tries to access a non existing
+    they stay NaN to throw an error if one tries to access a non existing
     quantity.
     If a particle with an unknown PDG is provided, a warning is thrown and and 
-    None is returned for charge, spin, and spin degeneracy.
+    np.nan is returned for charge, spin, and spin degeneracy.
 
     Attributes
     ----------
@@ -71,17 +71,8 @@ class Particle:
     Data
     -----
 
-    data_float_ :
-        The float data values in following order:
-        t, x, y, z, mass, E, px, py, pz, form_time, xsecfac, t_last_coll, weight
-    data_int_ :
-        The int data values in following order:
-        pdg, ID, ncoll, proc_id_orgin, pdg_mother1, pdg_mother2, status 
-    data_short_ :
-        The short data values in following order:
-        pdg_valid, charge, baryon_number, strangeness
-
-
+    data_ :
+        The data values given in the order before.
 
     Methods
     -------
@@ -207,17 +198,12 @@ class Particle:
     Notes
     -----
     If a member of the Particle class is not set or a quantity should be computed
-    and the needed member variables are not set, then `None` is returned by default.
+    and the needed member variables are not set, then `NaN` is returned by default.
     """
-    __slots__ = ['data_float_','data_int_', 'data_short_'] 
+    __slots__ = ['data_'] 
     def __init__(self,input_format=None,particle_array=None):
-        # t, x, y, z, mass, E, px, py, pz, form_time_, xsecfac_, t_last_coll_, weight_
-        self.data_float_ = np.array(13*[None],dtype = float)
-        # pdg, ID, ncoll, proc_id_orgin, pdg_mother1, pdg_mother2, status 
-        self.data_int_ = np.array(7*[None], dtype = int)
-        # pdg_valid, charge, baryon_number, strangeness
-        self.data_short_ = np.array(4*[None], dtype = short) 
-
+        self.data_ = np.array(25*[np.nan],dtype=np.float)
+        
         if ((input_format is not None) and (particle_array is None)) or ((input_format is None) and (particle_array is not None)):
             raise ValueError("'input_format' or 'particle_array' not given")
 
@@ -270,9 +256,9 @@ class Particle:
                 "px_": [6,6],
                 "py_": [7,7],
                 "pz_": [8,8],
-                "pdg_": [0,9],
-                "ID_": [1,10],
-                "charge_": [1,11],
+                "pdg_": [9,9],
+                "ID_": [11,10],
+                "charge_": [12,11],
             },
             "Oscar2013Extended": {
                 "t_": [0,0],
@@ -284,22 +270,22 @@ class Particle:
                 "px_": [6,6],
                 "py_": [7,7],
                 "pz_": [8,8],
-                "pdg_": [0,9],
-                "ID_": [1,10],
-                "charge_": [1,11],
-                "ncoll_": [2,12],
-                "form_time_": [9,11],
-                "xsecfac_": [10,14],
-                "proc_id_origin_": [3,15],
-                "proc_type_origin_": [4,16],
-                "t_last_coll_": [11,17],
-                "pdg_mother1_": [4,18],
-                "pdg_mother2_": [5,19],
-                "baryon_number_": [2,20],
-                "strangeness_": [3,21],
+                "pdg_": [9,9],
+                "ID_": [11,10],
+                "charge_": [12,11],
+                "ncoll_": [13,12],
+                "form_time_": [14,11],
+                "xsecfac_": [15,14],
+                "proc_id_origin_": [16,15],
+                "proc_type_origin_": [17,16],
+                "t_last_coll_": [18,17],
+                "pdg_mother1_": [19,18],
+                "pdg_mother2_": [20,19],
+                "baryon_number_": [22,20],
+                "strangeness_": [23,21],
             },
             "Oscar2013Extended_IC": {
-                "t_": [0,0],
+                 "t_": [0,0],
                 "x_": [1,1],
                 "y_": [2,2],
                 "z_": [3,3],
@@ -308,22 +294,22 @@ class Particle:
                 "px_": [6,6],
                 "py_": [7,7],
                 "pz_": [8,8],
-                "pdg_": [0,9],
-                "ID_": [1,10],
-                "charge_": [1,11],
-                "ncoll_": [2,12],
-                "form_time_": [9,11],
-                "xsecfac_": [10,14],
-                "proc_id_origin_": [3,15],
-                "proc_type_origin_": [4,16],
-                "t_last_coll_": [11,17],
-                "pdg_mother1_": [4,18],
-                "pdg_mother2_": [5,19],
-                "baryon_number_": [2,20],
-                "strangeness_": [3,21],
+                "pdg_": [9,9],
+                "ID_": [11,10],
+                "charge_": [12,11],
+                "ncoll_": [13,12],
+                "form_time_": [14,11],
+                "xsecfac_": [15,14],
+                "proc_id_origin_": [16,15],
+                "proc_type_origin_": [17,16],
+                "t_last_coll_": [18,17],
+                "pdg_mother1_": [19,18],
+                "pdg_mother2_": [20,19],
+                "baryon_number_": [22,20],
+                "strangeness_": [23,21],
             },
             "Oscar2013Extended_Photons": {
-                "t_": [0,0],
+                 "t_": [0,0],
                 "x_": [1,1],
                 "y_": [2,2],
                 "z_": [3,3],
@@ -332,23 +318,23 @@ class Particle:
                 "px_": [6,6],
                 "py_": [7,7],
                 "pz_": [8,8],
-                "pdg_": [0,9],
-                "ID_": [1,10],
-                "charge_": [1,11],
-                "ncoll_": [2,12],
-                "form_time_": [9,11],
-                "xsecfac_": [10,14],
-                "proc_id_origin_": [3,15],
-                "proc_type_origin_": [4,16],
-                "t_last_coll_": [11,17],
-                "pdg_mother1_": [4,18],
-                "pdg_mother2_": [5,19],
-                "weight_": [12,20],
+                "pdg_": [9,9],
+                "ID_": [11,10],
+                "charge_": [12,11],
+                "ncoll_": [13,12],
+                "form_time_": [14,11],
+                "xsecfac_": [15,14],
+                "proc_id_origin_": [16,15],
+                "proc_type_origin_": [17,16],
+                "t_last_coll_": [18,17],
+                "pdg_mother1_": [19,18],
+                "pdg_mother2_": [20,19],
+                "weight_": [24,20],
             },
             "JETSCAPE": {
-                "ID_": [1,10],
-                "pdg_": [0,9],
-                "status_": [6,2],
+                "ID_": [11,0],
+                "pdg_": [9,1],
+                "status_": [21,2],
                 "E_": [5,3],
                 "px_": [6,4],
                 "py_": [7,5],
@@ -361,28 +347,27 @@ class Particle:
                     and len(particle_array) >=  len(attribute_mapping[input_format])-2)):
                 for attribute, index in attribute_mapping[input_format].items():
                     if len(particle_array)<index[1]+1:
-                        setattr(self,attribute,None)
                         continue
                     # Type casting for specific attributes
                     if attribute in ["t_", "x_", "y_", "z_", "mass_", "E_", "px_", "py_", "pz_", "form_time_", "xsecfac_", "t_last_coll_", "weight_"]:
-                        self.data_float_[index[0]] = float(particle_array[index[1]])
+                        self.data_[index[0]] = float(particle_array[index[1]])
                     elif attribute in ["pdg_", "ID_", "ncoll_", "proc_id_origin_", "proc_type_origin_", "pdg_mother1_", "pdg_mother2_", "status_"]:
-                        self.data_int_[index[0]] = int(particle_array[index[1]])
+                        self.data_[index[0]] = int(particle_array[index[1]])
                     else:
-                        self.data_short_[index[0]] = int(particle_array[index[1]])
+                        self.data_[index[0]] = int(particle_array[index[1]])
 
                 if input_format == "JETSCAPE":
-                    self.mass_ = self.compute_mass_from_energy_momentum()
-                    self.charge_ = self.compute_charge_from_pdg()
+                    self.mass = self.compute_mass_from_energy_momentum()
+                    self.charge = self.compute_charge_from_pdg()
             else:
                 raise ValueError(f"The input file is corrupted!")
         else:
             raise ValueError(f"Unsupported input format '{input_format}'")
         
-        self.pdg_valid_ = PDGID(self.pdg_).is_valid
+        self.pdg_valid = PDGID(self.pdg).is_valid
 
-        if(not self.pdg_valid_):
-             warnings.warn('The PDG code ' + str(self.pdg_) + ' is not valid. '+
+        if(not self.pdg_valid):
+             warnings.warn('The PDG code ' + str(self.pdg) + ' is not valid. '+
                            'All properties extracted from the PDG are set to default values.')
 
     @property
@@ -391,13 +376,13 @@ class Particle:
 
         Returns
         -------
-        t_ : float
+        t : float
         """
-        return self.data_float_[0]
+        return self.data_[0]
 
     @t.setter
     def t(self,value):
-        self.data_float_[0] = value
+        self.data_[0] = value
 
     @property
     def x(self):
@@ -405,13 +390,13 @@ class Particle:
 
         Returns
         -------
-        x_ : float
+        x : float
         """
-        return self.data_float_[1]
+        return self.data_[1]
 
     @x.setter
     def x(self,value):
-        self.data_float_[1] = value
+        self.data_[1] = value
 
     @property
     def y(self):
@@ -419,13 +404,13 @@ class Particle:
 
         Returns
         -------
-        y_ : float
+        y : float
         """
-        return self.data_float_[2]
+        return self.data_[2]
 
     @y.setter
     def y(self,value):
-        self.data_float_[2] = value
+        self.data_[2] = value
 
     @property
     def z(self):
@@ -433,12 +418,12 @@ class Particle:
 
         Returns
         -------
-        z_ : float
+        z : float
         """
-        return self.data_float_[3]
+        return self.data_[3]
     @z.setter
     def z(self,value):
-        self.data_float_[4] = value
+        self.data_[3] = value
 
     @property
     def mass(self):
@@ -446,13 +431,13 @@ class Particle:
 
         Returns
         -------
-        mass_ : float
+        mass : float
         """
-        return self.data_float_[5]
+        return self.data_[4]
 
     @mass.setter
     def mass(self,value):
-        self.data_float_[5] = value
+        self.data_[4] = value
 
     @property
     def E(self):
@@ -460,13 +445,13 @@ class Particle:
 
         Returns
         -------
-        E_ : float
+        E : float
         """
-        return self.data_float_[6]
+        return self.data_[5]
 
     @E.setter
     def E(self,value):
-        self.data_float_[6] = value
+        self.data_[5] = value
 
     @property
     def px(self):
@@ -474,13 +459,13 @@ class Particle:
 
         Returns
         -------
-        px_ : float
+        px : float
         """
-        return self.data_float_[7]
+        return self.data_[6]
 
     @px.setter
     def px(self,value):
-        self.data_float_[7] = value
+        self.data_[6] = value
 
     @property
     def py(self):
@@ -488,13 +473,13 @@ class Particle:
 
         Returns
         -------
-        py_ : float
+        py : float
         """
-        return self.data_float_[8]
+        return self.data_[7]
 
     @py.setter
     def py(self,value):
-        self.data_float_[8] = value
+        self.data_[7] = value
 
     @property
     def pz(self):
@@ -502,13 +487,13 @@ class Particle:
 
         Returns
         -------
-        pz_ : float
+        pz : float
         """
-        return self.data_float_[9]
+        return self.data_[8]
 
     @pz.setter
     def pz(self,value):
-        self.data_float_[9] = value
+        self.data_[8] = value
 
     @property
     def pdg(self):
@@ -516,14 +501,14 @@ class Particle:
 
         Returns
         -------
-        pdg_ : int
+        pdg : int
         """
-        return self.data_int_[0]
+        return self.data_[9]
 
     @pdg.setter
     def pdg(self,value):
-        self.data_int_[0] = value
-        self.data_short_[0] = PDGID(self.pdg).is_valid
+        self.data_[9] = value
+        self.data_[10] = PDGID(self.pdg).is_valid
 
         if(not self.pdg_valid):
              warnings.warn('The PDG code ' + str(self.pdg) + ' is not valid. '+
@@ -537,13 +522,13 @@ class Particle:
 
         Returns
         -------
-        ID_ : int
+        ID : int
         """
-        return self.data_int_[1]
+        return self.data_[11]
 
     @ID.setter
     def ID(self,value):
-        self.data_int_[1] = value
+        self.data_[11] = value
 
     @property
     def charge(self):
@@ -551,13 +536,13 @@ class Particle:
 
         Returns
         -------
-        charge_ : short
+        charge : int
         """
-        return self.data_short_[1]
+        return self.data_[12]
 
     @charge.setter
     def charge(self,value):
-        self.data_short_[1] = value
+        self.data_[12] = value
 
     @property
     def ncoll(self):
@@ -565,13 +550,13 @@ class Particle:
 
         Returns
         -------
-        ncoll_ : int
+        ncoll : int
         """
-        return self.data_int_[2] 
+        return self.data_[13] 
 
     @ncoll.setter
     def ncoll(self,value):
-        self.data_int_[2]  = value
+        self.data_[13]  = value
 
     @property
     def form_time(self):
@@ -579,13 +564,13 @@ class Particle:
 
         Returns
         -------
-        form_time_ : float
+        form_time : float
         """
-        return self.data_float_[9] 
+        return self.data_[14] 
 
     @form_time.setter
     def form_time(self,value):
-        self.data_float_[9]  = value
+        self.data_[14]  = value
 
     @property
     def xsecfac(self):
@@ -593,13 +578,13 @@ class Particle:
 
         Returns
         -------
-        xsecfac_ : float
+        xsecfac : float
         """
-        return self.data_float_[10] 
+        return self.data_[15] 
 
     @xsecfac.setter
     def xsecfac(self,value):
-        self.data_float_[10]  = value
+        self.data_[15]  = value
 
     @property
     def proc_id_origin(self):
@@ -607,13 +592,13 @@ class Particle:
 
         Returns
         -------
-        proc_id_origin_ : int
+        proc_id_origin : int
         """
-        return self.data_int_[3]
+        return self.data_[16]
 
     @proc_id_origin.setter
     def proc_id_origin(self,value):
-        self.data_int_[3] = value
+        self.data_[16] = value
 
     @property
     def proc_type_origin(self):
@@ -621,13 +606,13 @@ class Particle:
 
         Returns
         -------
-        proc_type_origin_ : int
+        proc_type_origin : int
         """
-        return self.data_int_[4]
+        return self.data_[17]
 
     @proc_type_origin.setter
     def proc_type_origin(self,value):
-        self.data_int_[4] = value
+        self.data_[17] = value
 
     @property
     def t_last_coll(self):
@@ -635,13 +620,13 @@ class Particle:
 
         Returns
         -------
-        t_last_coll_ : float
+        t_last_coll : float
         """
-        return self.data_float_[11]
+        return self.data_[18]
 
     @t_last_coll.setter
     def t_last_coll(self,value):
-        self.data_float_[11] = value
+        self.data_[18] = value
 
     @property
     def pdg_mother1(self):
@@ -649,13 +634,13 @@ class Particle:
 
         Returns
         -------
-        pdg_mother1_ : int
+        pdg_mother1 : int
         """
-        return self.data_int_[5]
+        return self.data_[19]
 
     @pdg_mother1.setter
     def pdg_mother1(self,value):
-        self.data_int_[5] = value
+        self.data_[19] = value
 
     @property
     def pdg_mother2(self):
@@ -663,13 +648,13 @@ class Particle:
 
         Returns
         -------
-        pdg_mother2_ : int
+        pdg_mother2 : int
         """
-        return self.data_int_[6]
+        return self.data_[20]
 
     @pdg_mother2.setter
     def pdg_mother2(self,value):
-        self.data_int_[6] = value
+        self.data_[20] = value
 
     @property
     def status(self):
@@ -679,13 +664,13 @@ class Particle:
 
         Returns
         -------
-        status_ : int
+        status : int
         """
-        return self.data_int_[7]
+        return self.data_[21]
 
     @status.setter
     def status(self,value):
-        self.data_int_[7] = value
+        self.data_[21] = value
 
     @property
     def baryon_number(self):
@@ -693,13 +678,13 @@ class Particle:
 
         Returns
         -------
-        baryon_number_ : short
+        baryon_number : int
         """
-        return self.data_short_[2]
+        return self.data_[22]
  
     @baryon_number.setter
     def baryon_number(self,value):
-        self.data_short_[2] = value
+        self.data_[22] = value
 
     @property
     def strangeness(self):
@@ -707,13 +692,13 @@ class Particle:
 
         Returns
         -------
-        strangeness_ : short
+        strangeness : int
         """
-        return self.data_short_[3]
+        return self.data_[23]
 
     @strangeness.setter
     def strangeness(self,value):
-        self.data_short_[3] = value
+        self.data_[23] = value
 
     @property
     def weight(self):
@@ -721,13 +706,27 @@ class Particle:
 
         Returns
         -------
-        weight_ : float
+        weight : float
         """
-        return self.data_float_[12]
+        return self.data_[24]
 
     @weight.setter
     def weight(self,value):
-        self.data_float_[12] = value
+        self.data_[24] = value
+
+    @property
+    def pdg_valid(self):
+        """Get the weight of the particle.
+
+        Returns
+        -------
+        pdg_valid : int
+        """
+        return self.data_[10]
+
+    @weight.setter
+    def pdg_valid(self,value):
+        self.data_[10] = value
 
     def print_particle(self):
         """Print the whole particle information as csv string.
@@ -736,15 +735,20 @@ class Particle:
         All particle quantities are then printed in the next line separated by
         a comma.
         """
+        def int_isnan(value):
+            if np.isnan(value):
+                return np.nan
+            else:
+                return int(value)
         print('t,x,y,z,mass,E,px,py,pz,pdg,ID,charge,ncoll,form_time,xsecfac,\
               proc_id_origin,proc_type_origin,t_last_coll,pdg_mother1,\
               pdg_mother2,status,baryon_number,strangeness,weight')
         print(f'{self.t},{self.x},{self.y},{self.z},{self.mass},{self.E},\
-              {self.px},{self.py},{self.pz},{self.pdg},{self.ID},\
-              {self.charge},{self.ncoll},{self.form_time},{self.xsecfac},\
-              {self.proc_id_origin},{self.proc_type_origin}\
-              ,{self.t_last_coll},{self.pdg_mother1},{self.pdg_mother2},\
-              {self.status},{self.baryon_number},{self.strangeness},{self.weight}')
+              {self.px},{self.py},{self.pz},{int_isnan(self.pdg)},{int_isnan(self.ID)},\
+              {int_isnan(self.charge)},{int_isnan(self.ncoll)},{self.form_time},{self.xsecfac},\
+              {int_isnan(self.proc_id_origin)},{int_isnan(self.proc_type_origin)}\
+              ,{self.t_last_coll},{int_isnan(self.pdg_mother1)},{int_isnan(self.pdg_mother2)},\
+              {int_isnan(self.status)},{int_isnan(self.baryon_number)},{int_isnan(self.strangeness)},{self.weight}')
 
     def angular_momentum(self):
         """
@@ -758,12 +762,12 @@ class Particle:
 
         Notes
         -----
-        If one of the needed particle quantities is not given, then `None`
+        If one of the needed particle quantities is not given, then `np.nan`
         is returned. 
         """
-        if (self.x == None) or (self.y == None) or (self.z == None)\
-            (self.px == None) or (self.py == None) or (self.pz == None):
-            return None
+        if (self.x == np.nan) or (self.y == np.nan) or (self.z == np.nan)\
+            (self.px == np.nan) or (self.py == np.nan) or (self.pz == np.nan):
+            return np.nan
         else:
             r = [self.x, self.y, self.z]
             p = [self.px, self.py, self.pz]
@@ -780,11 +784,11 @@ class Particle:
         
         Notes
         -----
-        If one of the needed particle quantities is not given, then `None`
+        If one of the needed particle quantities is not given, then `np.nan`
         is returned.
         """
-        if (self.E == None) or (self.pz == None):
-            return None
+        if (self.E == np.nan) or (self.pz == np.nan):
+            return np.nan
         else:
             if abs(self.E - self.pz) < 1e-10:
                 denominator = (self.E - self.pz) + 1e-10  # Adding a small positive value
@@ -804,11 +808,11 @@ class Particle:
         
         Notes
         -----
-        If one of the needed particle quantities is not given, then `None`
+        If one of the needed particle quantities is not given, then `np.nan`
         is returned.
         """
-        if (self.px == None) or (self.py == None) or (self.pz == None):
-            return None
+        if (self.px == np.nan) or (self.py == np.nan) or (self.pz == np.nan):
+            return np.nan
         else:
             return np.sqrt(self.px**2.+self.py**2.+self.pz**2.)
 
@@ -823,11 +827,11 @@ class Particle:
         
         Notes
         -----
-        If one of the needed particle quantities is not given, then `None`
+        If one of the needed particle quantities is not given, then `np.nan`
         is returned.
         """
-        if (self.px == None) or (self.py == None):
-            return None
+        if (self.px == np.nan) or (self.py == np.nan):
+            return np.nan
         else:
             return np.sqrt(self.px**2.+self.py**2.)
 
@@ -842,11 +846,11 @@ class Particle:
 
         Notes
         -----
-        If one of the needed particle quantities is not given, then `None`
+        If one of the needed particle quantities is not given, then `np.nan`
         is returned.
         """
-        if (self.px == None) or (self.py == None):
-            return None
+        if (self.px == np.nan) or (self.py == np.nan):
+            return np.nan
         else:
             if (np.abs(self.px) < 1e-6) and (np.abs(self.py) < 1e-6):
                 return 0.
@@ -864,11 +868,11 @@ class Particle:
 
         Notes
         -----
-        If one of the needed particle quantities is not given, then `None`
+        If one of the needed particle quantities is not given, then `np.nan`
         is returned.
         """
-        if (self.px == None) or (self.py == None) or (self.pz == None):
-            return None
+        if (self.px == np.nan) or (self.py == np.nan) or (self.pz == np.nan):
+            return np.nan
         else:
             if self.p_abs() == 0:
                 return 0.
@@ -886,11 +890,11 @@ class Particle:
 
         Notes
         -----
-        If one of the needed particle quantities is not given, then `None`
+        If one of the needed particle quantities is not given, then `np.nan`
         is returned.
         """
-        if (self.px == None) or (self.py == None) or (self.pz == None):
-            return None
+        if (self.px == np.nan) or (self.py == np.nan) or (self.pz == np.nan):
+            return np.nan
         else:
             if abs(self.p_abs() - self.pz) < 1e-10:
                 denominator = (self.p_abs() - self.pz) + 1e-10  # Adding a small positive value
@@ -910,11 +914,11 @@ class Particle:
 
         Notes
         -----
-        If one of the needed particle quantities is not given, then `None`
+        If one of the needed particle quantities is not given, then `np.nan`
         is returned.
         """
-        if (self.t == None) or (self.z == None):
-            return None
+        if (self.t == np.nan) or (self.z == np.nan):
+            return np.nan
         else:
             if self.t > np.abs(self.z):
                 return 0.5 * np.log((self.t+self.z) / (self.t-self.z))
@@ -932,11 +936,11 @@ class Particle:
 
         Notes
         -----
-        If one of the needed particle quantities is not given, then `None`
+        If one of the needed particle quantities is not given, then `np.nan`
         is returned.
         """
-        if (self.t == None) or (self.z == None):
-            return None
+        if (self.t == np.nan) or (self.z == np.nan):
+            return np.nan
         else:
             if self.t > np.abs(self.z):
                 return np.sqrt(self.t**2.-self.z**2.)
@@ -954,11 +958,11 @@ class Particle:
 
         Notes
         -----
-        If one of the needed particle quantities is not given, then `None`
+        If one of the needed particle quantities is not given, then `np.nan`
         is returned.
         """
-        if (self.E == None) or (self.px == None) or (self.py == None) or (self.pz == None):
-            return None
+        if (self.E == np.nan) or (self.px == np.nan) or (self.py == np.nan) or (self.pz == np.nan):
+            return np.nan
         else:
             if np.abs(self.E**2. - self.p_abs()**2.) > 1e-16 and\
                   self.E**2. - self.p_abs()**2. > 0.:
@@ -980,10 +984,10 @@ class Particle:
         
         Notes
         -----
-        If the PDG ID is not known by `PDGID`, then `None` is returned.
+        If the PDG ID is not known by `PDGID`, then `np.nan` is returned.
         """
-        if not self.pdg_valid_:
-            return None
+        if not self.pdg_valid:
+            return np.nan
         return PDGID(self.pdg).charge
 
     def is_meson(self):
@@ -997,10 +1001,10 @@ class Particle:
 
         Notes
         -----
-        If the PDG ID is not known by `PDGID`, then `None` is returned.
+        If the PDG ID is not known by `PDGID`, then `np.nan` is returned.
         """
-        if not self.pdg_valid_:
-            return None
+        if not self.pdg_valid:
+            return np.nan
         return PDGID(self.pdg).is_meson
 
     def is_baryon(self):
@@ -1014,10 +1018,10 @@ class Particle:
 
         Notes
         -----
-        If the PDG ID is not known by `PDGID`, then `None` is returned.
+        If the PDG ID is not known by `PDGID`, then `np.nan` is returned.
         """
-        if not self.pdg_valid_:
-            return None
+        if not self.pdg_valid:
+            return np.nan
         return PDGID(self.pdg).is_baryon
 
     def is_hadron(self):
@@ -1031,10 +1035,10 @@ class Particle:
 
         Notes
         -----
-        If the PDG ID is not known by `PDGID`, then `None` is returned.
+        If the PDG ID is not known by `PDGID`, then `np.nan` is returned.
         """
-        if not self.pdg_valid_:
-            return None
+        if not self.pdg_valid:
+            return np.nan
         return PDGID(self.pdg).is_hadron
 
     def is_strange(self):
@@ -1048,10 +1052,10 @@ class Particle:
         
         Notes
         -----
-        If the PDG ID is not known by `PDGID`, then `None` is returned.
+        If the PDG ID is not known by `PDGID`, then `np.nan` is returned.
         """
-        if not self.pdg_valid_:
-            return None
+        if not self.pdg_valid:
+            return np.nan
         return PDGID(self.pdg).has_strange
 
     def is_heavy_flavor(self):
@@ -1065,10 +1069,10 @@ class Particle:
 
         Notes
         -----
-        If the PDG ID is not known by `PDGID`, then `None` is returned.
+        If the PDG ID is not known by `PDGID`, then `np.nan` is returned.
         """
-        if not self.pdg_valid_:
-            return None
+        if not self.pdg_valid:
+            return np.nan
         if PDGID(self.pdg).has_charm or PDGID(self.pdg).has_bottom\
               or PDGID(self.pdg).has_top:
             return True
@@ -1086,10 +1090,10 @@ class Particle:
         
         Notes
         -----
-        If the PDG ID is not known by `PDGID`, then `None` is returned.
+        If the PDG ID is not known by `PDGID`, then `np.nan` is returned.
         """
-        if not self.pdg_valid_:
-            return None
+        if not self.pdg_valid:
+            return np.nan
         return PDGID(self.pdg).J
            
     def spin_degeneracy(self):
@@ -1103,9 +1107,9 @@ class Particle:
 
         Notes
         -----
-        If the PDG ID is not known by `PDGID`, then `None` is returned.
+        If the PDG ID is not known by `PDGID`, then `np.nan` is returned.
         """
-        if not self.pdg_valid_:
-            return None
+        if not self.pdg_valid:
+            return np.nan
         return PDGID(self.pdg).j_spin
     

--- a/src/sparkx/Particle.py
+++ b/src/sparkx/Particle.py
@@ -15,142 +15,161 @@ class Particle:
 
     Attributes
     ----------
-    t_ : float
+    t : float
         The time of the particle.
-    x_ : float
+    x : float
         The x coordinate of the position.
-    y_ : float
+    y : float
         The y coordinate of the position.
-    z_ : float
+    z : float
         The z coordinate of the position.
-    mass_ : float
+    mass : float
         The mass of the particle.
-    E_ : float
+    E : float
         The energy of the particle.
-    px_ : float
+    px : float
         The x component of the momentum.
-    py_ : float
+    py : float
         The y component of the momentum.
-    pz_ : float
+    pz : float
         The z component of the momentum.
-    pdg_ : int
+    pdg : int
         The PDG code of the particle.
-    ID_ : int
+    pdg_is_valid : short
+        Is the PDG code valid?
+    ID : int
         The ID of the particle (unique label of each particle in an event).
-    charge_ : int
+    charge : short
         Electric charge of the particle.
-    ncoll_ : int
+    ncoll : int
         Number of collisions undergone by the particle.
-    form_time_ : double
+    form_time : double
         Formation time of the particle.
-    xsecfac_ : double
+    xsecfac : double
         Scaling factor of the cross section.
-    proc_id_origin_ : int
+    proc_id_origin : int
         ID for the process the particle stems from.
-    proc_type_origin_ : int
+    proc_type_origin : int
         Type information for the process the particle stems from.
-    t_last_coll_ : double
+    t_last_coll : double
         Time of the last collision.
-    pdg_mother1_ : int
+    pdg_mother1 : int
         PDG code of the mother particle 1.
-    pdg_mother2_ : int
+    pdg_mother2 : int
         PDG code of the mother particle 2.
-    status_ : int
+    status : int
         Status code of the particle.
-    baryon_number_ : int
+    baryon_number : short
         Baryon number of the particle.
-    strangeness_ : int
+    strangeness : short
         Strangeness quantum number of the particle.
-    weight_ : float
+    weight : float
         Weight of the particle.
+
+    These attributes are saved in following data structure:
+
+    Data
+    -----
+
+    data_float_ :
+        The float data values in following order:
+        t, x, y, z, mass, E, px, py, pz, form_time, xsecfac, t_last_coll, weight
+    data_int_ :
+        The int data values in following order:
+        pdg, ID, ncoll, proc_id_orgin, pdg_mother1, pdg_mother2, status 
+    data_short_ :
+        The short data values in following order:
+        pdg_valid, charge, baryon_number, strangeness
+
+
 
     Methods
     -------
-    t:
+    t :
         Get/set t
-    x:
+    x :
         Get/set x
-    y:
+    y :
         Get/set y
-    z:
+    z :
         Get/set z
-    mass:
+    mass :
         Get/set mass
-    E:
+    E :
         Get/set E
-    px:
+    px :
         Get/set px
-    py:
+    py :
         Get/set py
-    pz:
+    pz :
         Get/set pz
-    pdg:
+    pdg :
         Get/set pdg
-    ID:
+    ID :
         Get/set ID
-    charge:
+    charge :
         Get/set charge
-    ncoll:
+    ncoll :
         Get/set ncoll
-    form_time:
+    form_time :
         Get/set form_time
-    xsecfac:
+    xsecfac :
         Get/set xsecfactor
-    proc_id_origin:
+    proc_id_origin :
         Get/set proc_id_origin
-    proc_type_origin:
+    proc_type_origin :
         Get/set proc_type_origin
-    t_last_coll:
+    t_last_coll :
         Get/set t_last_coll
-    pdg_mother1:
+    pdg_mother1 :
         Get/set pdg_mother1
-    pdg_mother2:
+    pdg_mother2 :
         Get/set pdg_mother2
-    status:
+    status :
         Get/set status
-    baryon_number:
+    baryon_number :
         Get/set baryon_number
-    strangeness:
+    strangeness :
         Get/set strangeness
-    print_particle:
+    print_particle :
         Print the particle as CSV to terminal
-    angular_momentum:
+    angular_momentum :
         Compute angular momentum
-    momentum_rapidity_Y:
+    momentum_rapidity_Y :
         Compute momentum rapidity
-    p_abs:
+    p_abs :
         Compute absolute momentum
-    pt_abs:
+    pt_abs :
         Compute absolute value of transverse momentum
-    phi:
+    phi :
         Compute azimuthal angle
-    theta:
+    theta :
         Compute polar angle
-    pseudorapidity:
+    pseudorapidity :
         Compute pseudorapidity
-    spatial_rapidity:
+    spatial_rapidity :
         Compute spatial rapidity
-    proper_time:
+    proper_time :
         Compute proper time
-    compute_mass_from_energy_momentum:
+    compute_mass_from_energy_momentum :
         Compute mass from energy momentum relation
-    compute_charge_from_pdg:
+    compute_charge_from_pdg :
         Compute charge from PDG code
-    is_meson:
+    is_meson :
         Is the particle a meson?
-    is_baryon:
+    is_baryon :
         Is the particle a baryon?
-    is_hadron:
+    is_hadron :
         Is the particle a hadron?
-    is_strange:
+    is_strange :
         Is the particle a strange particle?
-    is_heavy_flavor:
+    is_heavy_flavor :
         Is the particle a heavy flavor particle?
-    weight:
+    weight :
         What is the weight of the particle?
-    spin:
+    spin :
         Total spin :math:`J` of the particle.
-    spin_degeneracy:
+    spin_degeneracy :
         Total spin :math:`2J + 1` of the particle.
     
 
@@ -190,43 +209,14 @@ class Particle:
     If a member of the Particle class is not set or a quantity should be computed
     and the needed member variables are not set, then `None` is returned by default.
     """
-    __slots__ = ['t_', 'x_', 'y_','z_','mass_', 'E_', 'px_', 'py_', 'pz_', 'pdg_', 'ID_', 'charge_', 'ncoll_',\
-                  'pdg_valid_','form_time_', 'xsecfac_', 'proc_id_origin_', 'proc_type_origin_', 't_last_coll_',\
-                      'pdg_mother1_', 'pdg_mother2_', 'status_', 'baryon_number_', 'strangeness_', 'weight_'] 
+    __slots__ = ['data_float_','data_int_', 'data_short_'] 
     def __init__(self,input_format=None,particle_array=None):
-        # OSCAR2013 parameters
-        self.t_ = None
-        self.x_ = None
-        self.y_ = None
-        self.z_ = None
-        self.mass_ = None
-        self.E_ = None
-        self.px_ = None
-        self.py_ = None
-        self.pz_ = None
-        self.pdg_ = None
-        self.pdg_valid_ = None
-        self.ID_ = None
-        self.charge_ = None
-
-        # OSCAR2013Extended / OSCAR2013Extended_IC parameters
-        self.ncoll_ = None
-        self.form_time_ = None
-        self.xsecfac_ = None
-        self.proc_id_origin_ = None
-        self.proc_type_origin_ = None
-        self.t_last_coll_ = None
-        self.pdg_mother1_ = None
-        self.pdg_mother2_ = None
-        self.baryon_number_ = None
-        self.strangeness_ = None
-
-        # Oscar2013Extended_Photons additional parameter 
-        # instead of baryon_number_
-        self.weight_ = None
-
-        # JETSCAPE unique parameter
-        self.status_ = None
+        # t, x, y, z, mass, E, px, py, pz, form_time_, xsecfac_, t_last_coll_, weight_
+        self.data_float_ = np.array(13*[None],dtype = float)
+        # pdg, ID, ncoll, proc_id_orgin, pdg_mother1, pdg_mother2, status 
+        self.data_int_ = np.array(7*[None], dtype = int)
+        # pdg_valid, charge, baryon_number, strangeness
+        self.data_short_ = np.array(4*[None], dtype = short) 
 
         if ((input_format is not None) and (particle_array is None)) or ((input_format is None) and (particle_array is not None)):
             raise ValueError("'input_format' or 'particle_array' not given")
@@ -267,100 +257,102 @@ class Particle:
         charge_) are computed based on energy-momentum and PDG code.
 
         """
+        #first entry: index in data array
+        #second entry: index in line
         attribute_mapping = {
             "Oscar2013": {
-                "t_": 0,
-                "x_": 1,
-                "y_": 2,
-                "z_": 3,
-                "mass_": 4,
-                "E_": 5,
-                "px_": 6,
-                "py_": 7,
-                "pz_": 8,
-                "pdg_": 9,
-                "ID_": 10,
-                "charge_": 11,
+                "t_": [0,0],
+                "x_": [1,1],
+                "y_": [2,2],
+                "z_": [3,3],
+                "mass_": [4,4],
+                "E_": [5,5],
+                "px_": [6,6],
+                "py_": [7,7],
+                "pz_": [8,8],
+                "pdg_": [0,9],
+                "ID_": [1,10],
+                "charge_": [1,11],
             },
             "Oscar2013Extended": {
-                "t_": 0,
-                "x_": 1,
-                "y_": 2,
-                "z_": 3,
-                "mass_": 4,
-                "E_": 5,
-                "px_": 6,
-                "py_": 7,
-                "pz_": 8,
-                "pdg_": 9,
-                "ID_": 10,
-                "charge_": 11,
-                "ncoll_": 12,
-                "form_time_": 13,
-                "xsecfac_": 14,
-                "proc_id_origin_": 15,
-                "proc_type_origin_": 16,
-                "t_last_coll_": 17,
-                "pdg_mother1_": 18,
-                "pdg_mother2_": 19,
-                "baryon_number_": 20,
-                "strangeness_": 21,
+                "t_": [0,0],
+                "x_": [1,1],
+                "y_": [2,2],
+                "z_": [3,3],
+                "mass_": [4,4],
+                "E_": [5,5],
+                "px_": [6,6],
+                "py_": [7,7],
+                "pz_": [8,8],
+                "pdg_": [0,9],
+                "ID_": [1,10],
+                "charge_": [1,11],
+                "ncoll_": [2,12],
+                "form_time_": [9,11],
+                "xsecfac_": [10,14],
+                "proc_id_origin_": [3,15],
+                "proc_type_origin_": [4,16],
+                "t_last_coll_": [11,17],
+                "pdg_mother1_": [4,18],
+                "pdg_mother2_": [5,19],
+                "baryon_number_": [2,20],
+                "strangeness_": [3,21],
             },
             "Oscar2013Extended_IC": {
-                "t_": 0,
-                "x_": 1,
-                "y_": 2,
-                "z_": 3,
-                "mass_": 4,
-                "E_": 5,
-                "px_": 6,
-                "py_": 7,
-                "pz_": 8,
-                "pdg_": 9,
-                "ID_": 10,
-                "charge_": 11,
-                "ncoll_": 12,
-                "form_time_": 13,
-                "xsecfac_": 14,
-                "proc_id_origin_": 15,
-                "proc_type_origin_": 16,
-                "t_last_coll_": 17,
-                "pdg_mother1_": 18,
-                "pdg_mother2_": 19,
-                "baryon_number_": 20,
-                "strangeness_": 21,
+                "t_": [0,0],
+                "x_": [1,1],
+                "y_": [2,2],
+                "z_": [3,3],
+                "mass_": [4,4],
+                "E_": [5,5],
+                "px_": [6,6],
+                "py_": [7,7],
+                "pz_": [8,8],
+                "pdg_": [0,9],
+                "ID_": [1,10],
+                "charge_": [1,11],
+                "ncoll_": [2,12],
+                "form_time_": [9,11],
+                "xsecfac_": [10,14],
+                "proc_id_origin_": [3,15],
+                "proc_type_origin_": [4,16],
+                "t_last_coll_": [11,17],
+                "pdg_mother1_": [4,18],
+                "pdg_mother2_": [5,19],
+                "baryon_number_": [2,20],
+                "strangeness_": [3,21],
             },
             "Oscar2013Extended_Photons": {
-                "t_": 0,
-                "x_": 1,
-                "y_": 2,
-                "z_": 3,
-                "mass_": 4,
-                "E_": 5,
-                "px_": 6,
-                "py_": 7,
-                "pz_": 8,
-                "pdg_": 9,
-                "ID_": 10,
-                "charge_": 11,
-                "ncoll_": 12,
-                "form_time_": 13,
-                "xsecfac_": 14,
-                "proc_id_origin_": 15,
-                "proc_type_origin_": 16,
-                "t_last_coll_": 17,
-                "pdg_mother1_": 18,
-                "pdg_mother2_": 19,
-                "weight_": 20,
+                "t_": [0,0],
+                "x_": [1,1],
+                "y_": [2,2],
+                "z_": [3,3],
+                "mass_": [4,4],
+                "E_": [5,5],
+                "px_": [6,6],
+                "py_": [7,7],
+                "pz_": [8,8],
+                "pdg_": [0,9],
+                "ID_": [1,10],
+                "charge_": [1,11],
+                "ncoll_": [2,12],
+                "form_time_": [9,11],
+                "xsecfac_": [10,14],
+                "proc_id_origin_": [3,15],
+                "proc_type_origin_": [4,16],
+                "t_last_coll_": [11,17],
+                "pdg_mother1_": [4,18],
+                "pdg_mother2_": [5,19],
+                "weight_": [12,20],
             },
             "JETSCAPE": {
-                "ID_": 0,
-                "pdg_": 1,
-                "status_": 2,
-                "E_": 3,
-                "px_": 4,
-                "py_": 5,
-                "pz_": 6,
+                "ID_": [1,10],
+                "pdg_": [0,9],
+                "status_": [6,2],
+                "E_": [5,3],
+                "px_": [6,4],
+                "py_": [7,5],
+                "pz_": [8,6],
             },
         }
         if (input_format in attribute_mapping):
@@ -368,16 +360,16 @@ class Particle:
                  and len(particle_array) <=  len(attribute_mapping[input_format])\
                     and len(particle_array) >=  len(attribute_mapping[input_format])-2)):
                 for attribute, index in attribute_mapping[input_format].items():
-                    if len(particle_array)<index+1:
+                    if len(particle_array)<index[1]+1:
                         setattr(self,attribute,None)
                         continue
                     # Type casting for specific attributes
                     if attribute in ["t_", "x_", "y_", "z_", "mass_", "E_", "px_", "py_", "pz_", "form_time_", "xsecfac_", "t_last_coll_", "weight_"]:
-                        setattr(self, attribute, float(particle_array[index]))
-                    elif attribute in ["pdg_", "ID_", "charge_", "ncoll_", "proc_id_origin_", "proc_type_origin_", "pdg_mother1_", "pdg_mother2_", "baryon_number_", "strangeness_", "status_"]:
-                        setattr(self, attribute, int(particle_array[index]))
+                        self.data_float_[index[0]] = float(particle_array[index[1]])
+                    elif attribute in ["pdg_", "ID_", "ncoll_", "proc_id_origin_", "proc_type_origin_", "pdg_mother1_", "pdg_mother2_", "status_"]:
+                        self.data_int_[index[0]] = int(particle_array[index[1]])
                     else:
-                        setattr(self, attribute, particle_array[index])
+                        self.data_short_[index[0]] = int(particle_array[index[1]])
 
                 if input_format == "JETSCAPE":
                     self.mass_ = self.compute_mass_from_energy_momentum()
@@ -401,11 +393,11 @@ class Particle:
         -------
         t_ : float
         """
-        return self.t_
+        return self.data_float_[0]
 
     @t.setter
     def t(self,value):
-        self.t_ = value
+        self.data_float_[0] = value
 
     @property
     def x(self):
@@ -415,11 +407,11 @@ class Particle:
         -------
         x_ : float
         """
-        return self.x_
+        return self.data_float_[1]
 
     @x.setter
     def x(self,value):
-        self.x_ = value
+        self.data_float_[1] = value
 
     @property
     def y(self):
@@ -429,11 +421,11 @@ class Particle:
         -------
         y_ : float
         """
-        return self.y_
+        return self.data_float_[2]
 
     @y.setter
     def y(self,value):
-        self.y_ = value
+        self.data_float_[2] = value
 
     @property
     def z(self):
@@ -443,11 +435,10 @@ class Particle:
         -------
         z_ : float
         """
-        return self.z_
-
+        return self.data_float_[3]
     @z.setter
     def z(self,value):
-        self.z_ = value
+        self.data_float_[4] = value
 
     @property
     def mass(self):
@@ -457,11 +448,11 @@ class Particle:
         -------
         mass_ : float
         """
-        return self.mass_
+        return self.data_float_[5]
 
     @mass.setter
     def mass(self,value):
-        self.mass_ = value
+        self.data_float_[5] = value
 
     @property
     def E(self):
@@ -471,11 +462,11 @@ class Particle:
         -------
         E_ : float
         """
-        return self.E_
+        return self.data_float_[6]
 
     @E.setter
     def E(self,value):
-        self.E_ = value
+        self.data_float_[6] = value
 
     @property
     def px(self):
@@ -485,11 +476,11 @@ class Particle:
         -------
         px_ : float
         """
-        return self.px_
+        return self.data_float_[7]
 
     @px.setter
     def px(self,value):
-        self.px_ = value
+        self.data_float_[7] = value
 
     @property
     def py(self):
@@ -499,11 +490,11 @@ class Particle:
         -------
         py_ : float
         """
-        return self.py_
+        return self.data_float_[8]
 
     @py.setter
     def py(self,value):
-        self.py_ = value
+        self.data_float_[8] = value
 
     @property
     def pz(self):
@@ -513,11 +504,11 @@ class Particle:
         -------
         pz_ : float
         """
-        return self.pz_
+        return self.data_float_[9]
 
     @pz.setter
     def pz(self,value):
-        self.pz_ = value
+        self.data_float_[9] = value
 
     @property
     def pdg(self):
@@ -527,15 +518,15 @@ class Particle:
         -------
         pdg_ : int
         """
-        return self.pdg_
+        return self.data_int_[0]
 
     @pdg.setter
     def pdg(self,value):
-        self.pdg_ = value
-        self.pdg_valid_ = PDGID(self.pdg_).is_valid
+        self.data_int_[0] = value
+        self.data_short_[0] = PDGID(self.pdg).is_valid
 
-        if(not self.pdg_valid_):
-             warnings.warn('The PDG code ' + str(self.pdg_) + ' is not valid. '+
+        if(not self.pdg_valid):
+             warnings.warn('The PDG code ' + str(self.pdg) + ' is not valid. '+
                            'All properties extracted from the PDG are set to None.')
 
     @property
@@ -548,11 +539,11 @@ class Particle:
         -------
         ID_ : int
         """
-        return self.ID_
+        return self.data_int_[1]
 
     @ID.setter
     def ID(self,value):
-        self.ID_ = value
+        self.data_int_[1] = value
 
     @property
     def charge(self):
@@ -560,13 +551,13 @@ class Particle:
 
         Returns
         -------
-        charge_ : int
+        charge_ : short
         """
-        return self.charge_
+        return self.data_short_[1]
 
     @charge.setter
     def charge(self,value):
-        self.charge_ = value
+        self.data_short_[1] = value
 
     @property
     def ncoll(self):
@@ -576,11 +567,11 @@ class Particle:
         -------
         ncoll_ : int
         """
-        return self.ncoll_
+        return self.data_int_[2] 
 
     @ncoll.setter
     def ncoll(self,value):
-        self.ncoll_ = value
+        self.data_int_[2]  = value
 
     @property
     def form_time(self):
@@ -590,11 +581,11 @@ class Particle:
         -------
         form_time_ : float
         """
-        return self.form_time_
+        return self.data_float_[9] 
 
     @form_time.setter
     def form_time(self,value):
-        self.form_time_ = value
+        self.data_float_[9]  = value
 
     @property
     def xsecfac(self):
@@ -604,11 +595,11 @@ class Particle:
         -------
         xsecfac_ : float
         """
-        return self.xsecfac_
+        return self.data_float_[10] 
 
     @xsecfac.setter
     def xsecfac(self,value):
-        self.xsecfac_ = value
+        self.data_float_[10]  = value
 
     @property
     def proc_id_origin(self):
@@ -618,11 +609,11 @@ class Particle:
         -------
         proc_id_origin_ : int
         """
-        return self.proc_id_origin_
+        return self.data_int_[3]
 
     @proc_id_origin.setter
     def proc_id_origin(self,value):
-        self.proc_id_origin_ = value
+        self.data_int_[3] = value
 
     @property
     def proc_type_origin(self):
@@ -632,11 +623,11 @@ class Particle:
         -------
         proc_type_origin_ : int
         """
-        return self.proc_type_origin_
+        return self.data_int_[4]
 
     @proc_type_origin.setter
     def proc_type_origin(self,value):
-        self.proc_type_origin_ = value
+        self.data_int_[4] = value
 
     @property
     def t_last_coll(self):
@@ -646,11 +637,11 @@ class Particle:
         -------
         t_last_coll_ : float
         """
-        return self.t_last_coll_
+        return self.data_float_[11]
 
     @t_last_coll.setter
     def t_last_coll(self,value):
-        self.t_last_coll_ = value
+        self.data_float_[11] = value
 
     @property
     def pdg_mother1(self):
@@ -660,11 +651,11 @@ class Particle:
         -------
         pdg_mother1_ : int
         """
-        return self.pdg_mother1_
+        return self.data_int_[5]
 
     @pdg_mother1.setter
     def pdg_mother1(self,value):
-        self.pdg_mother1_ = value
+        self.data_int_[5] = value
 
     @property
     def pdg_mother2(self):
@@ -674,11 +665,11 @@ class Particle:
         -------
         pdg_mother2_ : int
         """
-        return self.pdg_mother2_
+        return self.data_int_[6]
 
     @pdg_mother2.setter
     def pdg_mother2(self,value):
-        self.pdg_mother2_ = value
+        self.data_int_[6] = value
 
     @property
     def status(self):
@@ -690,11 +681,11 @@ class Particle:
         -------
         status_ : int
         """
-        return self.status_
+        return self.data_int_[7]
 
     @status.setter
     def status(self,value):
-        self.status_ = value
+        self.data_int_[7] = value
 
     @property
     def baryon_number(self):
@@ -702,13 +693,13 @@ class Particle:
 
         Returns
         -------
-        baryon_number_ : int
+        baryon_number_ : short
         """
-        return self.baryon_number_
+        return self.data_short_[2]
  
     @baryon_number.setter
     def baryon_number(self,value):
-        self.baryon_number_ = value
+        self.data_short_[2] = value
 
     @property
     def strangeness(self):
@@ -716,13 +707,13 @@ class Particle:
 
         Returns
         -------
-        strangeness_ : int
+        strangeness_ : short
         """
-        return self.strangeness_
+        return self.data_short_[3]
 
     @strangeness.setter
     def strangeness(self,value):
-        self.strangeness_ = value
+        self.data_short_[3] = value
 
     @property
     def weight(self):
@@ -732,11 +723,11 @@ class Particle:
         -------
         weight_ : float
         """
-        return self.weight_
+        return self.data_float_[12]
 
     @weight.setter
     def weight(self,value):
-        self.weight_ = value
+        self.data_float_[12] = value
 
     def print_particle(self):
         """Print the whole particle information as csv string.
@@ -748,12 +739,12 @@ class Particle:
         print('t,x,y,z,mass,E,px,py,pz,pdg,ID,charge,ncoll,form_time,xsecfac,\
               proc_id_origin,proc_type_origin,t_last_coll,pdg_mother1,\
               pdg_mother2,status,baryon_number,strangeness,weight')
-        print(f'{self.t_},{self.x_},{self.y_},{self.z_},{self.mass_},{self.E_},\
-              {self.px_},{self.py_},{self.pz_},{self.pdg_},{self.ID_},\
-              {self.charge_},{self.ncoll_},{self.form_time_},{self.xsecfac_},\
-              {self.proc_id_origin_},{self.proc_type_origin_}\
-              ,{self.t_last_coll_},{self.pdg_mother1_},{self.pdg_mother2_},\
-              {self.status_},{self.baryon_number_},{self.strangeness_},{self.weight_}')
+        print(f'{self.t},{self.x},{self.y},{self.z},{self.mass},{self.E},\
+              {self.px},{self.py},{self.pz},{self.pdg},{self.ID},\
+              {self.charge},{self.ncoll},{self.form_time},{self.xsecfac},\
+              {self.proc_id_origin},{self.proc_type_origin}\
+              ,{self.t_last_coll},{self.pdg_mother1},{self.pdg_mother2},\
+              {self.status},{self.baryon_number},{self.strangeness},{self.weight}')
 
     def angular_momentum(self):
         """

--- a/src/sparkx/Particle.py
+++ b/src/sparkx/Particle.py
@@ -348,7 +348,8 @@ class Particle:
                 for attribute, index in attribute_mapping[input_format].items():
                     if len(particle_array)<index[1]+1:
                         continue
-                    # Type casting for specific attributes
+                    # Type casting for specific attributes. Although everything is saved as a float, we will only read in int data for int fields
+                    # to ensure similar behaving as if we were reading in data into ints.
                     if attribute in ["t_", "x_", "y_", "z_", "mass_", "E_", "px_", "py_", "pz_", "form_time_", "xsecfac_", "t_last_coll_", "weight_"]:
                         self.data_[index[0]] = float(particle_array[index[1]])
                     elif attribute in ["pdg_", "ID_", "ncoll_", "proc_id_origin_", "proc_type_origin_", "pdg_mother1_", "pdg_mother2_", "status_"]:

--- a/src/sparkx/Particle.py
+++ b/src/sparkx/Particle.py
@@ -202,7 +202,7 @@ class Particle:
     """
     __slots__ = ['data_'] 
     def __init__(self,input_format=None,particle_array=None):
-        self.data_ = np.array(25*[np.nan],dtype=np.float)
+        self.data_ = np.array(25*[np.nan],dtype=float)
         
         if ((input_format is not None) and (particle_array is None)) or ((input_format is None) and (particle_array is not None)):
             raise ValueError("'input_format' or 'particle_array' not given")
@@ -274,7 +274,7 @@ class Particle:
                 "ID_": [11,10],
                 "charge_": [12,11],
                 "ncoll_": [13,12],
-                "form_time_": [14,11],
+                "form_time_": [14,13],
                 "xsecfac_": [15,14],
                 "proc_id_origin_": [16,15],
                 "proc_type_origin_": [17,16],
@@ -298,7 +298,7 @@ class Particle:
                 "ID_": [11,10],
                 "charge_": [12,11],
                 "ncoll_": [13,12],
-                "form_time_": [14,11],
+                "form_time_": [14,13],
                 "xsecfac_": [15,14],
                 "proc_id_origin_": [16,15],
                 "proc_type_origin_": [17,16],
@@ -322,7 +322,7 @@ class Particle:
                 "ID_": [11,10],
                 "charge_": [12,11],
                 "ncoll_": [13,12],
-                "form_time_": [14,11],
+                "form_time_": [14,13],
                 "xsecfac_": [15,14],
                 "proc_id_origin_": [16,15],
                 "proc_type_origin_": [17,16],
@@ -368,7 +368,7 @@ class Particle:
         self.pdg_valid = PDGID(self.pdg).is_valid
 
         if(not self.pdg_valid):
-             warnings.warn('The PDG code ' + str(self.pdg) + ' is not valid. '+
+             warnings.warn('The PDG code ' + str(int(self.pdg)) + ' is not valid. '+
                            'All properties extracted from the PDG are set to default values.')
 
     @property
@@ -509,10 +509,10 @@ class Particle:
     @pdg.setter
     def pdg(self,value):
         self.data_[9] = value
-        self.data_[10] = PDGID(self.pdg).is_valid
-
+        self.pdg_valid = PDGID(self.pdg).is_valid
+        
         if(not self.pdg_valid):
-             warnings.warn('The PDG code ' + str(self.pdg) + ' is not valid. '+
+             warnings.warn('The PDG code ' + str(int(self.pdg)) + ' is not valid. '+
                            'All properties extracted from the PDG are set to None.')
 
     @property
@@ -723,9 +723,9 @@ class Particle:
         -------
         pdg_valid : int
         """
-        return self.data_[10]
+        return bool(self.data_[10])
 
-    @weight.setter
+    @pdg_valid.setter
     def pdg_valid(self,value):
         self.data_[10] = value
 

--- a/src/sparkx/Particle.py
+++ b/src/sparkx/Particle.py
@@ -69,7 +69,7 @@ class Particle:
     These attributes are saved in following data structure:
 
     Data
-    -----
+    ----
 
     data_ :
         The data values given in the order before.
@@ -285,7 +285,7 @@ class Particle:
                 "strangeness_": [23,21],
             },
             "Oscar2013Extended_IC": {
-                 "t_": [0,0],
+                "t_": [0,0],
                 "x_": [1,1],
                 "y_": [2,2],
                 "z_": [3,3],
@@ -716,7 +716,7 @@ class Particle:
 
     @property
     def pdg_valid(self):
-        """Get the weight of the particle.
+        """Get the validity of the PDG code of the particle.
 
         Returns
         -------

--- a/tests/test_Particle.py
+++ b/tests/test_Particle.py
@@ -54,7 +54,6 @@ def test_pdg():
     # check valid particle
     p = Particle()
     p.pdg = 211
-    print(p.pdg)
     assert p.pdg == 211
     assert p.pdg_valid == True
 

--- a/tests/test_Particle.py
+++ b/tests/test_Particle.py
@@ -54,8 +54,9 @@ def test_pdg():
     # check valid particle
     p = Particle()
     p.pdg = 211
+    print(p.pdg)
     assert p.pdg == 211
-    assert p.pdg_valid_ == True
+    assert p.pdg_valid == True
 
     # check invalid particle
     with warnings.catch_warnings():
@@ -64,7 +65,7 @@ def test_pdg():
         q = Particle()
         q.pdg = 99999999
         assert q.pdg == 99999999
-        assert q.pdg_valid_ is False
+        assert q.pdg_valid is False
 
     # Check if a warning is issued
     with pytest.warns(UserWarning, match=r'The PDG code 99999999 is not valid. All properties extracted from the PDG are set to None.'):
@@ -266,4 +267,4 @@ def test_initialize_from_array_warning_invalid_pdg():
     with pytest.warns(UserWarning, match=r"The PDG code 99999999 is not valid."):
         p1 = Particle(input_format=format1, particle_array=array1)
 
-    assert p1.pdg_valid_ is False
+    assert p1.pdg_valid is False


### PR DESCRIPTION
Completely new approach of saving data. Instead of having dozens of float/int objects, everything is saved in a numpy array. This saves around 30% of RAM and some runtime on setup. 
This has two side effects: Before we used `None` objects for unset values. Now we use `nan`. All `ints` are now `floats`. The user will have to deal with this, and cast accordingly.
This is a very critical change, so I would ask both of you to have a look and catch any bug or unexpected side effect.
Please also check if you like what I did to the documentation.