### PR TITLE
Add particle tests and fix nan checks bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The main categories for changes in this file are:
 A `Deprecated` section could be added if needed for soon-to-be removed features.
 
 ## v1.1.1-Newton
+Date: 2023-12-20
 
 ### Added
 
@@ -32,6 +33,7 @@ A `Deprecated` section could be added if needed for soon-to-be removed features.
 [Link to diff from previous version](https://github.com/smash-transport/sparkx/compare/v1.1.0...v1.1.1)
 
 ## v1.1.0-Newton
+Date: 2023-12-07
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,19 @@ The main categories for changes in this file are:
 
 A `Deprecated` section could be added if needed for soon-to-be removed features.
 
+## v1.1.1-Newton
+
+### Added
+
+* Tests: Add tests for Particle class
+
+### Fixed
+
+* Particle: Fix bug in tests for `nan` values
+* Particle: Casts to `int` and `short` types added, which fixes the crash of `read_jet_data` in JetAnalysis (issue #174)
+
+[Link to diff from previous version](https://github.com/smash-transport/sparkx/compare/v1.1.0...v1.1.1)
+
 ## v1.1.0-Newton
 
 ### Added
@@ -52,8 +65,7 @@ A `Deprecated` section could be added if needed for soon-to-be removed features.
 * Particle: Functions using `PDGID` from the `particle` package handle now the case if the PDG ID is unknown to the package
 * Particle: Returns `nan` if the quantity is not known or can not be computed
 
-# Removed
-
+[Link to diff from previous version](https://github.com/smash-transport/sparkx/compare/v1.0.2...v1.1.0)
 
 ## v1.0.2-Newton
 Date: 2023-06-26

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sparkx"
-version = "1.1.0"
+version = "1.1.1"
 authors = [
     { name="Niklas Götz", email="goetz@fias.uni-frankfurt.de"},
     { name="Hendrik Roch", email="roch@fias.uni-frankfurt.de" },

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
         "fastjet==3.4.1.3"
         "matplotlib>=3.7.1"
     ],
-    version='1.1.0',
+    version='1.1.1',
     description='Software Package for Analyzing Relativistic Kinematics in Collision eXperiments',
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",

--- a/src/sparkx/Particle.py
+++ b/src/sparkx/Particle.py
@@ -35,7 +35,7 @@ class Particle:
         The z component of the momentum.
     pdg : int
         The PDG code of the particle.
-    pdg_is_valid : short
+    pdg_valid : short
         Is the PDG code valid?
     ID : int
         The ID of the particle (unique label of each particle in an event).
@@ -506,7 +506,7 @@ class Particle:
         -------
         pdg : int
         """
-        return self.data_[9]
+        return int(self.data_[9])
 
     @pdg.setter
     def pdg(self,value):
@@ -527,7 +527,7 @@ class Particle:
         -------
         ID : int
         """
-        return self.data_[11]
+        return int(self.data_[11])
 
     @ID.setter
     def ID(self,value):
@@ -541,7 +541,7 @@ class Particle:
         -------
         charge : int
         """
-        return self.data_[12]
+        return int(self.data_[12])
 
     @charge.setter
     def charge(self,value):
@@ -555,7 +555,7 @@ class Particle:
         -------
         ncoll : int
         """
-        return self.data_[13] 
+        return int(self.data_[13]) 
 
     @ncoll.setter
     def ncoll(self,value):
@@ -597,7 +597,7 @@ class Particle:
         -------
         proc_id_origin : int
         """
-        return self.data_[16]
+        return int(self.data_[16])
 
     @proc_id_origin.setter
     def proc_id_origin(self,value):
@@ -611,7 +611,7 @@ class Particle:
         -------
         proc_type_origin : int
         """
-        return self.data_[17]
+        return int(self.data_[17])
 
     @proc_type_origin.setter
     def proc_type_origin(self,value):
@@ -639,7 +639,7 @@ class Particle:
         -------
         pdg_mother1 : int
         """
-        return self.data_[19]
+        return int(self.data_[19])
 
     @pdg_mother1.setter
     def pdg_mother1(self,value):
@@ -653,7 +653,7 @@ class Particle:
         -------
         pdg_mother2 : int
         """
-        return self.data_[20]
+        return int(self.data_[20])
 
     @pdg_mother2.setter
     def pdg_mother2(self,value):
@@ -669,7 +669,7 @@ class Particle:
         -------
         status : int
         """
-        return self.data_[21]
+        return int(self.data_[21])
 
     @status.setter
     def status(self,value):
@@ -683,7 +683,7 @@ class Particle:
         -------
         baryon_number : int
         """
-        return self.data_[22]
+        return int(self.data_[22])
  
     @baryon_number.setter
     def baryon_number(self,value):
@@ -697,7 +697,7 @@ class Particle:
         -------
         strangeness : int
         """
-        return self.data_[23]
+        return int(self.data_[23])
 
     @strangeness.setter
     def strangeness(self,value):
@@ -723,7 +723,7 @@ class Particle:
 
         Returns
         -------
-        pdg_valid : int
+        pdg_valid : short
         """
         return bool(self.data_[10])
 

--- a/src/sparkx/Particle.py
+++ b/src/sparkx/Particle.py
@@ -768,8 +768,8 @@ class Particle:
         If one of the needed particle quantities is not given, then `np.nan`
         is returned. 
         """
-        if (self.x == np.nan) or (self.y == np.nan) or (self.z == np.nan)\
-            (self.px == np.nan) or (self.py == np.nan) or (self.pz == np.nan):
+        if np.isnan(self.x) or np.isnan(self.y) or np.isnan(self.z)\
+            or np.isnan(self.px) or np.isnan(self.py) or np.isnan(self.pz):
             return np.nan
         else:
             r = [self.x, self.y, self.z]
@@ -790,7 +790,7 @@ class Particle:
         If one of the needed particle quantities is not given, then `np.nan`
         is returned.
         """
-        if (self.E == np.nan) or (self.pz == np.nan):
+        if np.isnan(self.E) or np.isnan(self.pz):
             return np.nan
         else:
             if abs(self.E - self.pz) < 1e-10:
@@ -814,7 +814,7 @@ class Particle:
         If one of the needed particle quantities is not given, then `np.nan`
         is returned.
         """
-        if (self.px == np.nan) or (self.py == np.nan) or (self.pz == np.nan):
+        if np.isnan(self.px) or np.isnan(self.py) or np.isnan(self.pz):
             return np.nan
         else:
             return np.sqrt(self.px**2.+self.py**2.+self.pz**2.)
@@ -833,7 +833,7 @@ class Particle:
         If one of the needed particle quantities is not given, then `np.nan`
         is returned.
         """
-        if (self.px == np.nan) or (self.py == np.nan):
+        if np.isnan(self.px) or np.isnan(self.py):
             return np.nan
         else:
             return np.sqrt(self.px**2.+self.py**2.)
@@ -852,7 +852,7 @@ class Particle:
         If one of the needed particle quantities is not given, then `np.nan`
         is returned.
         """
-        if (self.px == np.nan) or (self.py == np.nan):
+        if np.isnan(self.px) or np.isnan(self.py):
             return np.nan
         else:
             if (np.abs(self.px) < 1e-6) and (np.abs(self.py) < 1e-6):
@@ -874,10 +874,10 @@ class Particle:
         If one of the needed particle quantities is not given, then `np.nan`
         is returned.
         """
-        if (self.px == np.nan) or (self.py == np.nan) or (self.pz == np.nan):
+        if np.isnan(self.px) or np.isnan(self.py) or np.isnan(self.pz):
             return np.nan
         else:
-            if self.p_abs() == 0:
+            if self.p_abs() == 0.0:
                 return 0.
             else:
                 return np.arccos(self.pz / self.p_abs())
@@ -896,7 +896,7 @@ class Particle:
         If one of the needed particle quantities is not given, then `np.nan`
         is returned.
         """
-        if (self.px == np.nan) or (self.py == np.nan) or (self.pz == np.nan):
+        if np.isnan(self.px) or np.isnan(self.py) or np.isnan(self.pz):
             return np.nan
         else:
             if abs(self.p_abs() - self.pz) < 1e-10:
@@ -920,7 +920,7 @@ class Particle:
         If one of the needed particle quantities is not given, then `np.nan`
         is returned.
         """
-        if (self.t == np.nan) or (self.z == np.nan):
+        if np.isnan(self.t) or np.isnan(self.z):
             return np.nan
         else:
             if self.t > np.abs(self.z):
@@ -942,7 +942,7 @@ class Particle:
         If one of the needed particle quantities is not given, then `np.nan`
         is returned.
         """
-        if (self.t == np.nan) or (self.z == np.nan):
+        if np.isnan(self.t) or np.isnan(self.z):
             return np.nan
         else:
             if self.t > np.abs(self.z):
@@ -954,6 +954,8 @@ class Particle:
         """
         Compute the mass from the energy momentum relation.
 
+        This function is called automatically if a JETSCAPE file is read in.
+
         Returns
         -------
         float
@@ -964,7 +966,7 @@ class Particle:
         If one of the needed particle quantities is not given, then `np.nan`
         is returned.
         """
-        if (self.E == np.nan) or (self.px == np.nan) or (self.py == np.nan) or (self.pz == np.nan):
+        if np.isnan(self.E) or np.isnan(self.px) or np.isnan(self.py) or np.isnan(self.pz):
             return np.nan
         else:
             if np.abs(self.E**2. - self.p_abs()**2.) > 1e-16 and\
@@ -977,8 +979,7 @@ class Particle:
         """
         Compute the charge from the PDG code.
 
-        This function is called automatically if a JETSCAPE file is read in with
-        the :meth:`ParticleClass.Particle.set_quantities_JETSCAPE` function.
+        This function is called automatically if a JETSCAPE file is read in.
 
         Returns
         -------

--- a/src/sparkx/Particle.py
+++ b/src/sparkx/Particle.py
@@ -35,11 +35,11 @@ class Particle:
         The z component of the momentum.
     pdg : int
         The PDG code of the particle.
-    pdg_valid : short
+    pdg_valid : bool
         Is the PDG code valid?
     ID : int
         The ID of the particle (unique label of each particle in an event).
-    charge : short
+    charge : int
         Electric charge of the particle.
     ncoll : int
         Number of collisions undergone by the particle.
@@ -59,9 +59,9 @@ class Particle:
         PDG code of the mother particle 2.
     status : int
         Status code of the particle.
-    baryon_number : short
+    baryon_number : int
         Baryon number of the particle.
-    strangeness : short
+    strangeness : int
         Strangeness quantum number of the particle.
     weight : float
         Weight of the particle.
@@ -723,7 +723,7 @@ class Particle:
 
         Returns
         -------
-        pdg_valid : short
+        pdg_valid : bool
         """
         return bool(self.data_[10])
 

--- a/tests/test_Particle.py
+++ b/tests/test_Particle.py
@@ -11,46 +11,55 @@ def test_t():
     p = Particle()
     p.t = 1.0
     assert p.t == 1.0
+    assert isinstance(p.t, float)
 
 def test_x():
     p = Particle()
     p.x = 1.0
     assert p.x == 1.0
+    assert isinstance(p.x, float)
 
 def test_y():
     p = Particle()
     p.y = 1.0
     assert p.y == 1.0
+    assert isinstance(p.y, float)
 
 def test_z():
     p = Particle()
     p.z = 1.0
     assert p.z == 1.0
+    assert isinstance(p.z, float)
 
 def test_mass():
     p = Particle()
     p.mass = 0.138
     assert p.mass == 0.138
+    assert isinstance(p.mass, float)
 
 def test_E():
     p = Particle()
     p.E = 1.0
     assert p.E == 1.0
+    assert isinstance(p.E, float)
 
 def test_px():
     p = Particle()
     p.px = 1.0
     assert p.px == 1.0
+    assert isinstance(p.px, float)
 
 def test_py():
     p = Particle()
     p.py = 1.0
     assert p.py == 1.0
+    assert isinstance(p.py, float)
 
 def test_pz():
     p = Particle()
     p.pz = 1.0
     assert p.pz == 1.0
+    assert isinstance(p.pz, float)
 
 def test_pdg():
     # check valid particle
@@ -58,6 +67,7 @@ def test_pdg():
     p.pdg = 211
     assert p.pdg == 211
     assert p.pdg_valid == True
+    assert isinstance(p.pdg, int)
 
     # check invalid particle
     with warnings.catch_warnings():
@@ -76,71 +86,85 @@ def test_ID():
     p = Particle()
     p.ID = 1
     assert p.ID == 1
+    assert isinstance(p.ID, int)
 
 def test_charge():
     p = Particle()
     p.charge = 1
     assert p.charge == 1
+    assert isinstance(p.charge, int)
 
 def test_ncoll():
     p = Particle()
     p.ncoll = 10
     assert p.ncoll == 10
+    assert isinstance(p.ncoll, int)
 
 def test_form_time():
     p = Particle()
     p.form_time = 1.0
     assert p.form_time == 1.0
+    assert isinstance(p.form_time, float)
 
 def test_xsecfac():
     p = Particle()
     p.xsecfac = 1.0
     assert p.xsecfac == 1.0
+    assert isinstance(p.xsecfac, float)
 
 def test_proc_id_origin():
     p = Particle()
     p.proc_id_origin = 1
     assert p.proc_id_origin == 1
+    assert isinstance(p.proc_id_origin, int)
 
 def test_proc_type_origin():
     p = Particle()
-    p.proc_id_origin = 1
-    assert p.proc_id_origin == 1
+    p.proc_type_origin = 1
+    assert p.proc_type_origin == 1
+    assert isinstance(p.proc_type_origin, int)
 
 def test_t_last_coll():
     p = Particle()
     p.t_last_coll = 10.0
     assert p.t_last_coll == 10.0
+    assert isinstance(p.t_last_coll, float)
 
 def test_pdg_mother1():
     p = Particle()
     p.pdg_mother1 = 211
     assert p.pdg_mother1 == 211
+    assert isinstance(p.pdg_mother1, int)
 
 def test_pdg_mother2():
     p = Particle()
     p.pdg_mother2 = 211
     assert p.pdg_mother2 == 211
+    assert isinstance(p.pdg_mother2, int)
 
 def test_baryon_number():
     p = Particle()
     p.baryon_number = 1
     assert p.baryon_number == 1
+    assert isinstance(p.baryon_number, int)
 
 def test_strangeness():
     p = Particle()
     p.strangeness = 1
     assert p.strangeness == 1
+    assert isinstance(p.strangeness, int)
 
 def test_weight():
     p = Particle()
     p.weight = 1.0
     assert p.weight == 1.0
+    assert isinstance(p.weight, float)
 
 def test_status():
     p = Particle()
     p.status = 27
     assert p.status == 27
+    assert isinstance(p.status, int)
 
 def test_initialize_from_array_valid_formats():
     format1 = "JETSCAPE"

--- a/tests/test_Particle.py
+++ b/tests/test_Particle.py
@@ -2,6 +2,8 @@ from sparkx.Particle import Particle
 import warnings
 import numpy as np
 import pytest
+import math
+from particle import PDGID
 
 # test the getter and setter functions in the case a particle object is created
 # by the user
@@ -267,3 +269,487 @@ def test_initialize_from_array_warning_invalid_pdg():
         p1 = Particle(input_format=format1, particle_array=array1)
 
     assert p1.pdg_valid is False
+
+def test_angular_momentum_valid_values():
+    p = Particle()
+    p.x = 1.0
+    p.y = 2.0
+    p.z = 3.0
+    p.px = 0.1
+    p.py = 0.2
+    p.pz = 0.3
+
+    result = p.angular_momentum()
+
+    expected_result = np.cross([1.0, 2.0, 3.0], [0.1, 0.2, 0.3])
+
+    assert np.array_equal(result, expected_result)
+
+def test_angular_momentum_missing_values():
+    p = Particle()
+    # Leave some values as np.nan
+
+    result = p.angular_momentum()
+
+    assert np.isnan(result).all()
+
+def test_angular_momentum_partial_missing_values():
+    p = Particle()
+    p.x = 1.0
+    p.y = 2.0
+    p.z = 3.0
+    # Leave momentum values as np.nan
+
+    result = p.angular_momentum()
+
+    assert np.isnan(result).all()
+
+def test_angular_momentum_zero_momentum():
+    p = Particle()
+    p.x = 1.0
+    p.y = 2.0
+    p.z = 3.0
+    p.px = 0.0
+    p.py = 0.0
+    p.pz = 0.0
+
+    result = p.angular_momentum()
+
+    assert np.array_equal(result, [0.0, 0.0, 0.0])
+
+def test_angular_momentum_zero_position():
+    p = Particle()
+    p.x = 0.0
+    p.y = 0.0
+    p.z = 0.0
+    p.px = 1.0
+    p.py = 2.0
+    p.pz = 3.0
+
+    result = p.angular_momentum()
+
+    assert np.array_equal(result, [0.0, 0.0, 0.0])
+
+def test_momentum_rapidity_Y_valid_values():
+    p = Particle()
+    p.E = 10.0
+    p.pz = 5.0
+
+    result = p.momentum_rapidity_Y()
+
+    expected_result = 0.5 * np.log((10.0 + 5.0) / (10.0 - 5.0))
+
+    assert np.isclose(result, expected_result)
+
+def test_momentum_rapidity_Y_zero_denominator():
+    p = Particle()
+    p.E = 5.0
+    p.pz = 5.0  # E == pz, should add a small positive value
+
+    result = p.momentum_rapidity_Y()
+    expected_result = 0.5 * np.log((5.0 + 5.0) / (1e-10))
+
+    assert np.isclose(result, expected_result)
+
+def test_momentum_rapidity_Y_missing_values():
+    p = Particle()
+    # Leave some values as np.nan
+
+    result = p.momentum_rapidity_Y()
+
+    assert np.isnan(result)
+
+def test_p_abs_valid_values():
+    p = Particle()
+    p.px = 1.0
+    p.py = 2.0
+    p.pz = 3.0
+
+    result = p.p_abs()
+
+    expected_result = np.sqrt(1.0**2 + 2.0**2 + 3.0**2)
+
+    assert np.isclose(result, expected_result)
+
+def test_p_abs_missing_values():
+    p = Particle()
+    # Leave some values as np.nan
+
+    result = p.p_abs()
+
+    assert np.isnan(result)
+
+def test_p_abs_zero_momentum():
+    p = Particle()
+    p.px = 0.0
+    p.py = 0.0
+    p.pz = 0.0
+
+    result = p.p_abs()
+
+    assert np.isclose(result, 0.0)
+
+def test_pt_abs_valid_values():
+    p = Particle()
+    p.px = 1.0
+    p.py = 2.0
+
+    result = p.pt_abs()
+
+    expected_result = np.sqrt(1.0**2 + 2.0**2)
+
+    assert np.isclose(result, expected_result)
+
+def test_pt_abs_missing_values():
+    p = Particle()
+    # Leave some values as np.nan
+
+    result = p.pt_abs()
+
+    assert np.isnan(result)
+
+def test_pt_abs_zero_transverse_momentum():
+    p = Particle()
+    p.px = 0.0
+    p.py = 0.0
+
+    result = p.pt_abs()
+
+    assert np.isclose(result, 0.0)
+
+def test_phi_valid_values():
+    p = Particle()
+    p.px = 1.0
+    p.py = 2.0
+
+    result = p.phi()
+
+    expected_result = math.atan2(2.0, 1.0)
+
+    assert np.isclose(result, expected_result)
+
+def test_phi_missing_values():
+    p = Particle()
+    # Leave some values as np.nan
+
+    result = p.phi()
+
+    assert np.isnan(result)
+
+def test_phi_zero_transverse_momentum():
+    p = Particle()
+    p.px = 0.0
+    p.py = 0.0
+
+    result = p.phi()
+
+    assert np.isclose(result, 0.0)
+
+def test_phi_small_transverse_momentum():
+    p = Particle()
+    p.px = 1e-7
+    p.py = 1e-7
+
+    result = p.phi()
+
+    assert np.isclose(result, 0.0)
+
+def test_theta_valid_values():
+    p = Particle()
+    p.px = 1.0
+    p.py = 2.0
+    p.pz = 3.0
+
+    result = p.theta()
+
+    expected_result = np.arccos(3.0 / np.sqrt(1.0**2 + 2.0**2 + 3.0**2))
+
+    assert np.isclose(result, expected_result)
+
+def test_theta_missing_values():
+    p = Particle()
+    # Leave some values as np.nan
+
+    result = p.theta()
+
+    assert np.isnan(result)
+
+def test_theta_zero_momentum():
+    p = Particle()
+    p.px = 0.0
+    p.py = 0.0
+    p.pz = 0.0
+
+    result = p.theta()
+
+    assert np.isclose(result, 0.0)
+
+def test_pseudorapidity_valid_values():
+    p = Particle()
+    p.px = 1.0
+    p.py = 2.0
+    p.pz = 3.0
+
+    result = p.pseudorapidity()
+
+    expected_result = 0.5 * np.log((np.sqrt(1.0**2 + 2.0**2 + 3.0**2) + 3.0) / (np.sqrt(1.0**2 + 2.0**2 + 3.0**2) - 3.0))
+
+    assert np.isclose(result, expected_result)
+
+def test_pseudorapidity_missing_values():
+    p = Particle()
+    # Leave some values as np.nan
+
+    result = p.pseudorapidity()
+
+    assert np.isnan(result)
+
+def test_pseudorapidity_zero_momentum():
+    p = Particle()
+    p.px = 0.0
+    p.py = 0.0
+    p.pz = 1.0
+
+    result = p.pseudorapidity()
+    expected_result = 0.5 * np.log(2./1e-10)
+
+    assert np.isclose(result, expected_result)
+
+def test_spatial_rapidity_valid_values():
+    p = Particle()
+    p.t = 5.0
+    p.z = 3.0
+
+    result = p.spatial_rapidity()
+
+    expected_result = 0.5 * np.log((5.0 + 3.0) / (5.0 - 3.0))
+
+    assert np.isclose(result, expected_result)
+
+def test_spatial_rapidity_missing_values():
+    p = Particle()
+    # Leave some values as np.nan
+
+    result = p.spatial_rapidity()
+
+    assert np.isnan(result)
+
+def test_spatial_rapidity_invalid_values():
+    p = Particle()
+    p.t = 3.0
+    p.z = 5.0
+
+    with pytest.raises(ValueError, match=r"|z| < t not fulfilled"):
+        p.spatial_rapidity()
+
+def test_proper_time_valid_values():
+    p = Particle()
+    p.t = 5.0
+    p.z = 3.0
+
+    result = p.proper_time()
+
+    expected_result = np.sqrt(5.0**2 - 3.0**2)
+
+    assert np.isclose(result, expected_result)
+
+def test_proper_time_missing_values():
+    p = Particle()
+    # Leave some values as np.nan
+
+    result = p.proper_time()
+
+    assert np.isnan(result)
+
+def test_proper_time_invalid_values():
+    p = Particle()
+    p.t = 3.0
+    p.z = 5.0
+
+    with pytest.raises(ValueError, match=r"|z| < t not fulfilled"):
+        p.proper_time()
+
+def test_compute_mass_from_energy_momentum_valid_values():
+    p = Particle()
+    p.E = 3.0
+    p.px = 1.0
+    p.py = 2.0
+    p.pz = 2.0
+
+    result = p.compute_mass_from_energy_momentum()
+
+    expected_result = np.sqrt(3.0**2 - (1.0**2 + 2.0**2 + 2.0**2))
+
+    assert np.isclose(result, expected_result)
+
+def test_compute_mass_from_energy_momentum_missing_values():
+    p = Particle()
+    # Leave some values as np.nan
+
+    result = p.compute_mass_from_energy_momentum()
+
+    assert np.isnan(result)
+
+def test_compute_mass_from_energy_momentum_zero_energy():
+    p = Particle()
+    p.E = 0.0
+    p.px = 0.0
+    p.py = 0.0
+    p.pz = 0.0
+
+    result = p.compute_mass_from_energy_momentum()
+
+    assert np.isclose(result, 0.0)
+
+def test_compute_charge_from_pdg_valid_values():
+    p = Particle()
+    p.pdg = 211  # Assuming PDG code for a positive pion
+
+    result = p.compute_charge_from_pdg()
+
+    expected_result = PDGID(211).charge
+
+    assert result == expected_result
+
+def test_compute_charge_from_pdg_invalid_values():
+    p = Particle()
+    p.pdg_valid = False
+    # Leave pdg as an invalid value
+
+    result = p.compute_charge_from_pdg()
+
+    assert np.isnan(result)
+
+def test_is_meson_from_pdg_valid_values():
+    p = Particle()
+    p.pdg = 211  # Assuming PDG code for a positive pion
+
+    result = p.is_meson()
+
+    expected_result = PDGID(211).is_meson
+
+    assert result == expected_result
+
+def test_is_meson_from_pdg_invalid_values():
+    p = Particle()
+    p.pdg_valid = False
+    # Leave pdg as an invalid value
+
+    result = p.is_meson()
+
+    assert np.isnan(result)
+
+def test_is_baryon_from_pdg_valid_values():
+    p = Particle()
+    p.pdg = 211  # Assuming PDG code for a positive pion
+
+    result = p.is_baryon()
+
+    expected_result = PDGID(211).is_baryon
+
+    assert result == expected_result
+
+def test_is_baryon_from_pdg_invalid_values():
+    p = Particle()
+    p.pdg_valid = False
+    # Leave pdg as an invalid value
+
+    result = p.is_baryon()
+
+    assert np.isnan(result)
+
+def test_is_hadron_from_pdg_valid_values():
+    p = Particle()
+    p.pdg = 211  # Assuming PDG code for a positive pion
+
+    result = p.is_hadron()
+
+    expected_result = PDGID(211).is_hadron
+
+    assert result == expected_result
+
+def test_is_hadron_from_pdg_invalid_values():
+    p = Particle()
+    p.pdg_valid = False
+    # Leave pdg as an invalid value
+
+    result = p.is_hadron()
+
+    assert np.isnan(result)
+
+def test_is_strange_from_pdg_valid_values():
+    p = Particle()
+    p.pdg = 211  # Assuming PDG code for a positive pion
+
+    result = p.is_strange()
+
+    expected_result = PDGID(211).has_strange
+
+    assert result == expected_result
+
+def test_is_strange_from_pdg_invalid_values():
+    p = Particle()
+    p.pdg_valid = False
+    # Leave pdg as an invalid value
+
+    result = p.is_strange()
+
+    assert np.isnan(result)
+
+def test_is_heavy_flavor_from_pdg_valid_values():
+    p = Particle()
+    p.pdg = 211  # Assuming PDG code for a positive pion
+
+    result = p.is_heavy_flavor()
+
+    expected_result = PDGID(211).has_charm or PDGID(211).has_bottom\
+          or PDGID(211).has_top
+
+    assert result == expected_result
+
+def test_is_heavy_flavor_from_pdg_invalid_values():
+    p = Particle()
+    p.pdg_valid = False
+    # Leave pdg as an invalid value
+
+    result = p.is_heavy_flavor()
+
+    assert np.isnan(result)
+
+def test_spin_from_pdg_valid_values():
+    p = Particle()
+    p.pdg = 211  # Assuming PDG code for a positive pion
+
+    result = p.spin()
+
+    expected_result = PDGID(211).J
+
+    assert result == expected_result
+
+def test_spin_from_pdg_invalid_values():
+    p = Particle()
+    p.pdg_valid = False
+    # Leave pdg as an invalid value
+
+    result = p.spin()
+
+    assert np.isnan(result)
+
+def test_spin_degeneracy_from_pdg_valid_values():
+    p = Particle()
+    p.pdg = 211  # Assuming PDG code for a positive pion
+
+    result = p.spin_degeneracy()
+
+    expected_result = PDGID(211).j_spin
+
+    assert result == expected_result
+
+def test_spin_degeneracy_from_pdg_invalid_values():
+    p = Particle()
+    p.pdg_valid = False
+    # Leave pdg as an invalid value
+
+    result = p.spin_degeneracy()
+
+    assert np.isnan(result)


### PR DESCRIPTION
This PR fixes some bugs in the Particle class. Today I wanted to complete the tests for the class and I realized, that we tested in all functions with `self.x == np.nan`, which should be `np.isnan(self.x)`.
I fixed this now in this PR and added test functions for all Particle class functions.

@NGoetz @nilssass Do we want to release a 1.1.1 version to fix this?