### PR TITLE
Add next version of PyPI GH action

### DIFF
--- a/.github/workflows/PyPI_release.yml
+++ b/.github/workflows/PyPI_release.yml
@@ -21,6 +21,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install -r requirements.txt
         pip install setuptools wheel twine
 
     - name: Build and publish

--- a/setup.py
+++ b/setup.py
@@ -5,12 +5,12 @@ setup(
     packages=find_packages(where='src/sparkx'),
     package_dir={'': 'sparkx'},
     install_requires=[
-        "particle==0.23.0"
-        "numpy>=1.23.5"
-        "scipy>=1.10.1"
-        "abc-property==1.0"
-        "fastjet==3.4.1.3"
-        "matplotlib>=3.7.1"
+        "particle==0.23.0",
+        "numpy>=1.23.5",
+        "scipy>=1.10.1",
+        "abc-property==1.0",
+        "fastjet==3.4.1.3",
+        "matplotlib>=3.7.1",
     ],
     version='1.1.0',
     description='Software Package for Analyzing Relativistic Kinematics in Collision eXperiments',


### PR DESCRIPTION
This tries to resolve issue #175. If you have any comments or requests for further changes, please add them here. I tried to iterate through the error of the last triggered action with ChatGPT, which is the result. There may be more needed. I think if we publish a v1.1.1, then this is a good test to see if the action can finish.