### PR TITLE
Add Zenodo badge and fix contributors rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,5 +13,9 @@
   <img src="https://img.shields.io/badge/docs-mkdocs%20material-blue.svg?style=flat" alt="documentation">
 </a>
 
+<a href="https://doi.org/10.5281/zenodo.10288638">
+  <img src="https://zenodo.org/badge/DOI/10.5281/zenodo.10288638.svg" alt="DOI">
+</a>
+
 This package is designed to assist users of the [SMASH](https://smash-transport.github.io/) and [JETSCAPE/X-SCAPE](https://jetscape.org/) codes to analyze the output of the simulation data.
 It contains multiple classes to read in the simulation outputs in OSCAR2013/OSCAR2013Extended format or the hadron output of JETSCAPE/X-SCAPE.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -42,7 +42,6 @@ autosummary_generate = True
 # You can specify multiple suffix as a list of string:
 #
 source_suffix = ['.rst', '.md']
-#source_suffix = '.rst'
 
 # The master toctree document.
 master_doc = 'index'

--- a/docs/source/credits.md
+++ b/docs/source/credits.md
@@ -1,0 +1,2 @@
+```{include} ../../CONTRIBUTORS.md
+```

--- a/docs/source/credits.rst
+++ b/docs/source/credits.rst
@@ -1,1 +1,0 @@
-.. include:: ../../CONTRIBUTORS.md

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,6 +9,10 @@ SPARKX
 
    <h2 style="font-size: 18px;">Software Package for Analyzing Relativistic Kinematics in Collision eXperiments</b></h2>
 
+   <a href="https://doi.org/10.5281/zenodo.10288638">
+      <img src="https://zenodo.org/badge/DOI/10.5281/zenodo.10288638.svg" alt="DOI">
+   </a>
+
 This package is designed to assist users of the `SMASH <https://smash-transport.github.io/>`_ and `JETSCAPE/X-SCAPE <https://jetscape.org/>`_ codes to analyze the output of the simulation data.
 It contains multiple classes to read in the simulation outputs in OSCAR2013/OSCAR2013Extended format or the hadron output of JETSCAPE/X-SCAPE.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -23,7 +23,7 @@ It contains multiple classes to read in the simulation outputs in OSCAR2013/OSCA
    classes/index
    utilities/index
    license
-   credits
+   credits.md
 
 
 Indices and tables

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,9 +1,0 @@
-particle
-numpy
-scipy
-fastjet
-sphinx
-numpydoc
-myst-parser
-sphinx-rtd-theme
-abc-property


### PR DESCRIPTION
This PR implements the Zenodo badge with the DOI for all versions of SPARKX in the README.md and in the index.rst file of the documentation.
I also fixed the rendering of the "Credits" section in the documentation. There was a problem with rendering the list from CONTRIBUTORS.md in markdown format.
There was also a requirements.txt file in the documentation directory, which is not needed.