### PR TITLE
Fix bug in remove_particle_species filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ The main categories for changes in this file are:
 
 A `Deprecated` section could be added if needed for soon-to-be removed features.
 
+## v1.2.0-Newton
+Date:
+
+### Fixed
+
+* Oscar/Jetscape: Fixed bug in `remove_particle_species` filter function if only one PDG id is given (issue #182)
+
+[Link to diff from previous version](https://github.com/smash-transport/sparkx/compare/v1.1.1...v1.2.0)
+
 ## v1.1.1-Newton
 Date: 2023-12-20
 

--- a/src/sparkx/Filter.py
+++ b/src/sparkx/Filter.py
@@ -137,7 +137,7 @@ def remove_particle_species(particle_list, pdg_list):
 
         for i in range(0, len(particle_list)):
             particle_list[i] = [elem for elem in particle_list[i]
-                                        if (int(elem.pdg) != pdg_list and not np.isnanelem.pdg)]
+                                        if (int(elem.pdg) != pdg_list and not np.isnan(elem.pdg))]
 
     elif isinstance(pdg_list, (list, np.ndarray, tuple)):
         pdg_list = np.asarray(pdg_list, dtype=np.int64)


### PR DESCRIPTION
This fixes the bug in the remove_particle_species function in the filters.

This closes #182.