### PR TITLE
Keyword argument fix for Oscar and Jetscape

### DIFF
--- a/src/sparkx/Jetscape.py
+++ b/src/sparkx/Jetscape.py
@@ -163,7 +163,7 @@ class Jetscape:
     Let's assume we only want to keep pions in events with a
     multiplicity > 500:
 
-        >>> jetscape = Jetscape(JETSCAPE_FILE_PATH, kwargs={'filters':{'multiplicity_cut':500, 'particle_species':(211, -211, 111)}})
+        >>> jetscape = Jetscape(JETSCAPE_FILE_PATH, filters={'multiplicity_cut':500, 'particle_species':(211, -211, 111)}})
         >>>
         >>> # print the pions to a jetscape file
         >>> jetscape.print_particle_lists_to_file('./particle_lists.dat')
@@ -186,6 +186,10 @@ class Jetscape:
         self.num_events_ = None
         self.particle_list_ = None
         self.optional_arguments_ = kwargs
+
+        for keys in self.optional_arguments_.keys():
+            if keys not in ['events', 'filters']:
+                raise ValueError('Unknown keyword argument used in constructor')
 
         if 'events' in self.optional_arguments_.keys() and isinstance(self.optional_arguments_['events'], tuple):
             if self.optional_arguments_['events'][0] > self.optional_arguments_['events'][1]:

--- a/src/sparkx/Jetscape.py
+++ b/src/sparkx/Jetscape.py
@@ -364,7 +364,7 @@ class Jetscape:
                     if int(line[2]) == first_event_header:
                         continue
                     else:
-                        if 'filters' in kwargs.keys():
+                        if 'filters' in self.optional_arguments_.keys():
                             data = self.__apply_kwargs_filters([data],kwargs['filters'])[0]
                             self.num_output_per_event_[len(particle_list)]=(len(particle_list),len(data))
                         particle_list.append(data)

--- a/src/sparkx/Oscar.py
+++ b/src/sparkx/Oscar.py
@@ -177,7 +177,7 @@ class Oscar:
     Let's assume we only want to keep participant pions in events with a
     multiplicity > 500:
 
-        >>> oscar = Oscar(OSCAR_FILE_PATH, kwargs={'filters':{'multiplicity_cut':500, 'participants':True, 'particle_species':(211, -211, 111)}})
+        >>> oscar = Oscar(OSCAR_FILE_PATH, filters={'multiplicity_cut':500, 'participants':True, 'particle_species':(211, -211, 111)})
         >>>
         >>> # print the pions to an oscar file
         >>> oscar.print_particle_lists_to_file('./particle_lists.oscar')
@@ -220,6 +220,10 @@ class Oscar:
         self.particle_list_ = None
         self.optional_arguments_ = kwargs
         self.event_end_lines_ = []
+
+        for keys in self.optional_arguments_.keys():
+            if keys not in ['events', 'filters']:
+                raise ValueError('Unknown keyword argument used in constructor')
 
         if 'events' in self.optional_arguments_.keys() and isinstance(self.optional_arguments_['events'], tuple):
             if self.optional_arguments_['events'][0] > self.optional_arguments_['events'][1]:
@@ -418,7 +422,7 @@ class Oscar:
                 elif 'event' in line and ('out' in line or 'in ' in line):
                     continue
                 elif '#' in line and 'end' in line:
-                    if 'filters' in kwargs.keys():
+                    if 'filters' in self.optional_arguments_.keys():
                         data = self.__apply_kwargs_filters([data],kwargs['filters'])[0]
                         self.num_output_per_event_[len(particle_list)]=(len(particle_list),len(data))
                     particle_list.append(data)


### PR DESCRIPTION
This fixes the documentation and ensures that we have no wrong keyword arguments in the call.