### PR TITLE
Fix printout bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ Date:
 * Oscar/Jetscape: Fix bug in `pseudorapidity_cut` filter function if only one cut value is given (issue #188)
 * Oscar/Jetscape: Fix bug in keyword argument parsing
 * ReactionPlaneFlow: Fix bug in particle weight
-
+* Oscar: Fix various bugs in printout
 [Link to diff from previous version](https://github.com/smash-transport/sparkx/compare/v1.1.1...v1.2.0)
 
 ## v1.1.1-Newton

--- a/src/sparkx/Oscar.py
+++ b/src/sparkx/Oscar.py
@@ -1023,7 +1023,7 @@ class Oscar:
         header = []
         event_footer = ''
         format_oscar2013 = '%g %g %g %g %g %.9g %.9g %.9g %.9g %d %d %d'
-        format_oscar2013_extended = '%g %g %g %g %g %.9g %.9g %.9g %.9g %d %d %d %d %g %g %d %d %g %d %d %d'
+        format_oscar2013_extended = '%g %g %g %g %g %.9g %.9g %.9g %.9g %d %d %d %d %g %g %d %d %g %d %d'
 
         with open(self.PATH_OSCAR_,'r') as oscar_file:
             counter_line = 0
@@ -1053,8 +1053,12 @@ class Oscar:
                     event = self.num_output_per_event_[i,0]
                     num_out = self.num_output_per_event_[i,1]
                     particle_output = np.asarray(self.particle_list()[i])
-
                     f_out.write('# event '+ str(event)+' out '+ str(num_out)+'\n')
+                    if len(particle_output) == 0:
+                        f_out.write(self.event_end_lines_[event])
+                        continue
+                    elif (i == 0 and len(particle_output[0])>20  and self.oscar_format_ == 'Oscar2013Extended'):
+                        format_oscar2013_extended = format_oscar2013_extended + (len(particle_output[0])-20)*' %d'
                     if self.oscar_format_ == 'Oscar2013':
                         np.savetxt(f_out, particle_output, delimiter=' ', newline='\n', fmt=format_oscar2013)
                     elif self.oscar_format_ == 'Oscar2013Extended'  or self.oscar_format_ == 'Oscar2013Extended_IC' or self.oscar_format_ == 'Oscar2013Extended_Photons':
@@ -1065,6 +1069,12 @@ class Oscar:
                 num_out = self.num_output_per_event_[0][1]
                 particle_output = np.asarray(self.particle_list())
                 f_out.write('# event '+ str(event)+' out '+ str(num_out)+'\n')
+                if len(particle_output) == 0:
+                    f_out.write(self.event_end_lines_[event])
+                    f_out.close()
+                    return
+                elif (len(particle_output[0])>20  and self.oscar_format_ == 'Oscar2013Extended'):
+                        format_oscar2013_extended = format_oscar2013_extended + (len(particle_output[0])-20)*' %d'
                 if self.oscar_format_ == 'Oscar2013':
                     np.savetxt(f_out, particle_output, delimiter=' ', newline='\n', fmt=format_oscar2013)
                 elif self.oscar_format_ == 'Oscar2013Extended'  or self.oscar_format_ == 'Oscar2013Extended_IC' or self.oscar_format_ == 'Oscar2013Extended_Photons':

--- a/src/sparkx/Particle.py
+++ b/src/sparkx/Particle.py
@@ -347,7 +347,7 @@ class Particle:
                  and len(particle_array) <=  len(attribute_mapping[input_format])\
                     and len(particle_array) >=  len(attribute_mapping[input_format])-2)):
                 for attribute, index in attribute_mapping[input_format].items():
-                    if len(particle_array)<index[1]+1:
+                    if len(particle_array)<=(index[1]):
                         continue
                     # Type casting for specific attributes. Although everything is saved as a float, we will only read in int data for int fields
                     # to ensure similar behaving as if we were reading in data into ints.
@@ -683,6 +683,8 @@ class Particle:
         -------
         baryon_number : int
         """
+        if np.isnan(self.data_[22]):
+            return np.nan
         return int(self.data_[22])
  
     @baryon_number.setter
@@ -697,6 +699,8 @@ class Particle:
         -------
         strangeness : int
         """
+        if np.isnan(self.data_[23]):
+            return np.nan
         return int(self.data_[23])
 
     @strangeness.setter

--- a/tests/test_Oscar.py
+++ b/tests/test_Oscar.py
@@ -1,4 +1,5 @@
 from sparkx.Oscar import Oscar
+import filecmp
 import numpy as np
 import pytest
 import os
@@ -9,9 +10,19 @@ def oscar_file_path():
     return os.path.join(os.path.dirname(__file__), 'test_files', 'particle_lists.oscar')
 
 @pytest.fixture
+def output_path():
+    # Assuming your test file is in the same directory as test_files/
+    return os.path.join(os.path.dirname(__file__), 'test_files', 'test_output.oscar')
+
+@pytest.fixture
 def oscar_extended_file_path():
     # Assuming your test file is in the same directory as test_files/
     return os.path.join(os.path.dirname(__file__), 'test_files', 'particle_lists_extended.oscar')
+
+@pytest.fixture
+def oscar_old_extended_file_path():
+    # Assuming your test file is in the same directory as test_files/
+    return os.path.join(os.path.dirname(__file__), 'test_files', 'particle_lists_extended_old.oscar')
 
 
 def test_constructor_invalid_initialization(oscar_file_path):
@@ -41,3 +52,20 @@ def test_constructor_invalid_initialization(oscar_file_path):
     with pytest.raises(IndexError):
         Oscar(oscar_file_path, events=(5, 10))
         
+def test_extended_oscar_print(oscar_extended_file_path, output_path):
+    oscar = Oscar(oscar_extended_file_path)
+    oscar.print_particle_lists_to_file(output_path)
+    assert filecmp.cmp(oscar_extended_file_path, output_path)
+    os.remove(output_path) 
+
+def test_old_extended_oscar_print(oscar_old_extended_file_path, output_path):
+    oscar = Oscar(oscar_old_extended_file_path)
+    oscar.print_particle_lists_to_file(output_path)
+    assert filecmp.cmp(oscar_old_extended_file_path, output_path)
+    os.remove(output_path)  
+
+def test_standard_oscar_print(oscar_file_path, output_path):
+    oscar = Oscar(oscar_file_path)
+    oscar.print_particle_lists_to_file(output_path)
+    assert filecmp.cmp(oscar_file_path, output_path)
+    os.remove(output_path) 

--- a/tests/test_files/particle_lists_extended_old.oscar
+++ b/tests/test_files/particle_lists_extended_old.oscar
@@ -1,0 +1,11 @@
+#!OSCAR2013Extended particle_lists t x y z mass p0 px py pz pdg ID charge ncoll form_time xsecfac proc_id_origin proc_type_origin time_last_coll pdg_mother1 pdg_mother2
+# Units: fm fm fm fm GeV GeV GeV GeV GeV none none e none fm none none none fm none none
+# SMASH-3.1rc-23-g59a05e65f
+# event 0 out 4
+200 1.19982 2.4656 66.6003 0.938 0.969041054 -0.0062451792 -0.0679376012 0.233542383 2112 0 0 0 -5.76975 1 0 0 0 0 0
+200 -35.1206 3.67917 53.7048 0.938 0.999183602 -0.187411374 0.0248889149 0.28771755 2112 1 0 1 -5.76975 1 14 1 17.2191 0 0
+200 -36.0241 -72.3435 0.292269 0.938 1.02984689 -0.198371594 -0.375935324 0.00787130722 2112 2 0 1 -5.76975 1 7 1 9.56613 0 0
+200 -0.327458 -1.03495 63.4848 0.938 0.970534111 -0.0728987705 0.0500597969 0.232964045 2112 3 0 0 -5.76975 1 0 0 0 0 0
+# event 0 end 0 impact   0.000 scattering_projectile_target yes
+# event 1 out 0
+# event 1 end 0 impact   0.000 scattering_projectile_target yes


### PR DESCRIPTION
This fixes issue #169 . Having empty events or old input formats was not supported by the Oscar printout. This has been fixed.
@nilssass : This also adds some tests for this function.