### PR TITLE
Add filter tests to Jetscape tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Date:
 * ReactionPlaneFlow: Fix bug in particle weight
 * Oscar: Fix various bugs in printout
 * EventCharacteristics: Fix sign of the eccentricity
+* Jetscape: Fix bug in keyword argument filtering, where filters were not applied to the last event
 
 [Link to diff from previous version](https://github.com/smash-transport/sparkx/compare/v1.1.1...v1.2.0)
 

--- a/src/sparkx/EventCharacteristics.py
+++ b/src/sparkx/EventCharacteristics.py
@@ -66,7 +66,7 @@ class EventCharacteristics:
         >>>
         >>> # compute epsilon2 for the first event
         >>> event_characterization = EventCharacteristics(oscar[0])
-        >>> eps2 = event_characterization.eccentricity(2, weight_quantitiy = "number")
+        >>> eps2 = event_characterization.eccentricity(2, weight_quantity = "number")
 
     """
     def __init__(self, event_data):

--- a/src/sparkx/Jetscape.py
+++ b/src/sparkx/Jetscape.py
@@ -354,7 +354,7 @@ class Jetscape:
             elif i == 'particle_status':
                 event = particle_status(event, filters_dict['particle_status'])
             else:
-                raise ValueError('The cut is unkown!')
+                raise ValueError('The cut is unknown!')
 
         return event
 
@@ -372,6 +372,9 @@ class Jetscape:
                 if not line:
                     raise IndexError('Index out of range of JETSCAPE file')
                 elif '#' in line and 'sigmaGen' in line:
+                    if 'filters' in self.optional_arguments_.keys():
+                        data = self.__apply_kwargs_filters([data],kwargs['filters'])[0]
+                        self.num_output_per_event_[len(particle_list)]=(len(particle_list)+1,len(data))
                     particle_list.append(data)
                 elif i == 0 and '#' not in line and 'weight' not in line:
                     raise ValueError('First line of the event is not a comment ' +\
@@ -389,7 +392,7 @@ class Jetscape:
                     else:
                         if 'filters' in self.optional_arguments_.keys():
                             data = self.__apply_kwargs_filters([data],kwargs['filters'])[0]
-                            self.num_output_per_event_[len(particle_list)]=(len(particle_list),len(data))
+                            self.num_output_per_event_[len(particle_list)]=(len(particle_list)+1,len(data))
                         particle_list.append(data)
                         data = []
                 else:
@@ -700,7 +703,7 @@ class Jetscape:
         Parameters
         ----------
         cut_value : float
-            If a single value is passed, the cut is applyed symmetrically
+            If a single value is passed, the cut is applied symmetrically
             around 0.
             For example, if cut_value = 1, only particles with rapidity in
             [-1.0, 1.0] are kept.
@@ -728,7 +731,7 @@ class Jetscape:
         Parameters
         ----------
         cut_value : float
-            If a single value is passed, the cut is applyed symmetrically
+            If a single value is passed, the cut is applied symmetrically
             around 0.
             For example, if cut_value = 1, only particles with pseudo-rapidity
             in [-1.0, 1.0] are kept.

--- a/src/sparkx/Jetscape.py
+++ b/src/sparkx/Jetscape.py
@@ -274,7 +274,7 @@ class Jetscape:
         Parameters
         ----------
         fname : variable name
-            Name of the variable for the file opend with the :code:`open()`
+            Name of the variable for the file opened with the :code:`open()`
             command.
 
         """

--- a/src/sparkx/Lattice3D.py
+++ b/src/sparkx/Lattice3D.py
@@ -918,8 +918,8 @@ class Lattice3D:
         A tuple containing the following:
         slice_data : ndarray
             The 2D slice data extracted from the lattice.
-        slice_values : tupel of 2 ndarrays
-            A tupel of coordinate lists containing the 2D coordinates of the slice.
+        slice_values : tuple of 2 ndarrays
+            A tuple of coordinate lists containing the 2D coordinates of the slice.
         slice_label : str
             The label describing the slice plane.
 

--- a/src/sparkx/Oscar.py
+++ b/src/sparkx/Oscar.py
@@ -653,7 +653,7 @@ class Oscar:
         Returns a numpy array containing the event number (starting with 1)
         and the corresponding number of particles created in this event as
 
-        num_output_per_event[event_n, numer_of_particles_in_event_n]
+        num_output_per_event[event_n, number_of_particles_in_event_n]
 
         num_output_per_event is updated with every manipulation e.g. after
         applying cuts.

--- a/src/sparkx/Oscar.py
+++ b/src/sparkx/Oscar.py
@@ -426,7 +426,7 @@ class Oscar:
             elif i == 'multiplicity_cut':
                 event = multiplicity_cut(event, filters_dict['multiplicity_cut'])
             else:
-                raise ValueError('The cut is unkown!')
+                raise ValueError('The cut is unknown!')
 
         return event
 
@@ -801,7 +801,7 @@ class Oscar:
 
         Returns
         -------
-        self : Oscar oject
+        self : Oscar object
             Containing participants in every event only
         """
 
@@ -947,7 +947,7 @@ class Oscar:
         Parameters
         ----------
         cut_value : float
-            If a single value is passed, the cut is applyed symmetrically
+            If a single value is passed, the cut is applied symmetrically
             around 0.
             For example, if cut_value = 1, only particles with pseudo-rapidity
             in [-1.0, 1.0] are kept.

--- a/src/sparkx/Particle.py
+++ b/src/sparkx/Particle.py
@@ -595,7 +595,7 @@ class Particle:
 
     @property
     def xsecfac(self):
-        """Get or set the crosssection scaling factor of the particle.
+        """Get or set the cross section scaling factor of the particle.
 
         Returns
         -------

--- a/src/sparkx/Utilities.py
+++ b/src/sparkx/Utilities.py
@@ -13,7 +13,7 @@ import csv
 def pdg_to_latex(pdg_id):
     """
     Converts a given PDG ID or a list of PDG IDs into the corresponding LaTeX
-    formatted particle name as sts or a list of LaTeX formated particle names
+    formatted particle name as sts or a list of LaTeX formatted particle names
     as str which has the same order as the input PDG IDs
 
     Parameters
@@ -24,7 +24,7 @@ def pdg_to_latex(pdg_id):
     Returns
     -------
     latex_names : str / list
-        LaTeX formated particle name or list of LaTeX formated particle names
+        LaTeX formatted particle name or list of LaTeX formatted particle names
         in the same order as the input PDG IDs.
 
     Examples

--- a/src/sparkx/flow/PCAFlow.py
+++ b/src/sparkx/flow/PCAFlow.py
@@ -37,10 +37,10 @@ class PCAFlow(FlowInterface.FlowInterface):
     n : int, optional
         The flow harmonic to compute. Must be a positive integer. Default is 2.
     alpha : int, optional
-        The order in subleading flow up to which the flow is computed. 
+        The order in sub-leading flow up to which the flow is computed. 
         Must be an integer greater than or equal to 1. Default is 2.
     number_subcalc : int, optional
-        The number of subcalculations to estimate the error of the flow. 
+        The number of sub-calculations to estimate the error of the flow. 
         Must be an integer greater than or equal to 2. Default is 4.
 
     Methods
@@ -56,36 +56,36 @@ class PCAFlow(FlowInterface.FlowInterface):
     n_ : int
         The flow harmonic to compute.
     alpha_ : int
-        The order in subleading flow up to which the flow is computed.
+        The order in sub-leading flow up to which the flow is computed.
     number_subcalc_ : int
-        The number of subcalculations to estimate the error of the flow.
+        The number of sub-calculations to estimate the error of the flow.
     number_events_ : int or None
         The total number of events.
     subcalc_counter_ : int
-        A counter to keep track of the current subcalculation.
+        A counter to keep track of the current sub-calculation.
     normalization_ : None or numpy.ndarray
         Normalization factors for each bin.
     bin_multiplicity_total_ : None or numpy.ndarray
         Total multiplicity in each bin across all events.
     sigma_multiplicity_total_ : list of numpy.ndarray
         List of arrays containing the multiplicity in each bin for each 
-        subcalculation.
+        sub-calculation.
     number_events_subcalc_ : None or numpy.ndarray
-        Number of events used in each subcalculation.
+        Number of events used in each sub-calculation.
     QnRe_total_ : None or numpy.ndarray
         Real part of the flow vector for each bin across all events.
     QnIm_total_ : None or numpy.ndarray
         Imaginary part of the flow vector for each bin across all events.
     SigmaQnReSub_total_ : None or numpy.ndarray
-        Real part of the flow vector for each bin and subcalculation.
+        Real part of the flow vector for each bin and sub-calculation.
     SigmaQnImSub_total_ : None or numpy.ndarray
-        Imaginary part of the flow vector for each bin and subcalculation.
+        Imaginary part of the flow vector for each bin and sub-calculation.
     VnDelta_total_ : None or numpy.ndarray
         Covariance matrix for flow vectors across all events.
     SigmaVnDelta_total_ : None or numpy.ndarray
-        Covariance matrix for flow vectors for each subcalculation.
+        Covariance matrix for flow vectors for each sub-calculation.
     FlowSubCalc_ : None or numpy.ndarray
-        An array containing the flow magnitude for subcalculations.
+        An array containing the flow magnitude for sub-calculations.
     Flow_ : None or numpy.ndarray
         An array containing the flow magnitude.
     FlowUncertainty_ : None or numpy.ndarray
@@ -113,7 +113,7 @@ class PCAFlow(FlowInterface.FlowInterface):
         else:
             self.n_ = n
 
-        # order in subleading flow up to which the flow is computed
+        # order in sub-leading flow up to which the flow is computed
         if not isinstance(alpha, int):
             raise TypeError('alpha has to be int')
         elif alpha < 1:
@@ -121,7 +121,7 @@ class PCAFlow(FlowInterface.FlowInterface):
         else:
             self.alpha_ = alpha
 
-        # number of subcalculations to estimate the error of the flow
+        # number of sub-calculations to estimate the error of the flow
         if not isinstance(number_subcalc, int):
             raise TypeError('number_subcalc has to be int')
         elif number_subcalc < 2:
@@ -202,7 +202,7 @@ class PCAFlow(FlowInterface.FlowInterface):
             self.VnDelta_total_ = np.zeros((number_bins,number_bins))
             self.SigmaVnDelta_total_ = np.zeros((number_bins,number_bins,self.number_subcalc_))
 
-        # update the subcalculation counter if needed
+        # update the sub-calculation counter if needed
         number_events_subcalc = self.number_events_//self.number_subcalc_
         if (event_number%number_events_subcalc == 0) and (event_number != 0) and (self.subcalc_counter_ < self.number_subcalc_-1):
             self.subcalc_counter_ += 1

--- a/src/sparkx/flow/QCumulantFlow.py
+++ b/src/sparkx/flow/QCumulantFlow.py
@@ -10,13 +10,12 @@
 from sparkx.flow import FlowInterface
 import numpy as np
 import random as rd
-import warnings
 
 rd.seed(42)
 
 class QCumulantFlow(FlowInterface.FlowInterface):
     """
-    This class implements the Q-cumulant method for anisotropic flow analysis.
+    This class implements the Q-Cumulant method for anisotropic flow analysis.
 
     References:
 

--- a/tests/test_CentralityClasses.py
+++ b/tests/test_CentralityClasses.py
@@ -9,6 +9,7 @@
     
 import pytest
 import numpy as np
+import os
 from sparkx.CentralityClasses import CentralityClasses
 
 
@@ -66,9 +67,9 @@ def test_get_centrality_class(centrality_obj):
     assert centrality_obj.get_centrality_class(29) == 7
 
 def test_output_centrality_classes(centrality_obj, tmp_path):
-    output_file = tmp_path / "centrality_output.txt"
+    output_file = os.path.join(tmp_path,"centrality_output.txt")
     centrality_obj.output_centrality_classes(str(output_file))
-    assert output_file.is_file()
+    assert os.path.isfile(output_file)
 
     # Check content of the output file
     with open(output_file, 'r') as f:

--- a/tests/test_EventCharacteristics.py
+++ b/tests/test_EventCharacteristics.py
@@ -140,14 +140,14 @@ def test_eccentricity_from_lattice(test_Lattice3D_instance):
     with pytest.raises(ValueError):
         eve_char.eccentricity(2,harmonic_m=0,weight_quantity="number")
 
-def test_eBQS_densities_Milne_from_OSCAR_IC(oscar_particle_objects_list,test_Lattice3D_instance, fake_particle_list_eccentricity, initial_particles):
+def test_eBQS_densities_Milne_from_OSCAR_IC(tmp_path,oscar_particle_objects_list,test_Lattice3D_instance, fake_particle_list_eccentricity, initial_particles):
     x_min = y_min = z_min = -3.
     x_max = y_max = z_max = 3.
     Nx = Ny = Nz = 100
     n_sigma_x = n_sigma_y = n_sigma_z = 2
     sigma_smear = 0.3
     eta_range = [-1,1,10]
-    output_filename = 'test_eBQS_densities_Milne_from_OSCAR_IC.dat'
+    output_filename = os.path.join(tmp_path,'test_eBQS_densities_Milne_from_OSCAR_IC.dat')
 
     #test error if IC_info is not None and string
     with pytest.raises(TypeError):
@@ -313,13 +313,13 @@ def test_eBQS_densities_Milne_from_OSCAR_IC(oscar_particle_objects_list,test_Lat
     assert np.isclose(integral, 2., atol=1e-1), "Energy density integral is not close to 2"
 
         
-def test_eBQS_densities_Minkowski_from_OSCAR_IC(oscar_particle_objects_list,test_Lattice3D_instance):
+def test_eBQS_densities_Minkowski_from_OSCAR_IC(tmp_path,oscar_particle_objects_list,test_Lattice3D_instance):
     x_min = y_min = z_min = -5.
     x_max = y_max = z_max = 5.
     Nx = Ny = Nz = 50
     n_sigma_x = n_sigma_y = n_sigma_z = 3
     sigma_smear = 0.2
-    output_filename = 'test_eBQS_densities_Minkowski_from_OSCAR_IC.dat'
+    output_filename = os.path.join(tmp_path,'test_eBQS_densities_Minkowski_from_OSCAR_IC.dat')
 
     # test error if IC_info is not None and string
     with pytest.raises(TypeError):
@@ -400,4 +400,4 @@ def test_eBQS_densities_Minkowski_from_OSCAR_IC(oscar_particle_objects_list,test
                                                              n_sigma_x, n_sigma_y,
                                                              n_sigma_z, sigma_smear, 
                                                              1)
-        
+    

--- a/tests/test_Filter.py
+++ b/tests/test_Filter.py
@@ -309,7 +309,7 @@ def particle_list_pseudorapidity():
         particle_list.append(p)
     return [particle_list]
 
-def test_rapidity_cut(particle_list_pseudorapidity):
+def test_pseudorapidity_cut(particle_list_pseudorapidity):
     test_cases = [
         # Test cases for valid input
         (0.5,None,None, [[particle_list_pseudorapidity[0][0]]]),

--- a/tests/test_Jetscape.py
+++ b/tests/test_Jetscape.py
@@ -12,6 +12,7 @@ import pytest
 import random
 import numpy as np
 import filecmp
+import copy
 from sparkx.Jetscape import Jetscape
 from sparkx.Particle import Particle
 
@@ -65,7 +66,7 @@ def create_temporary_jetscape_file(path, num_events, output_per_event_list=None)
             else:
                 num_outputs = output_per_event_list[event_number]
 
-            event_info = f"#	Event	{event_number}	weight	1	EPangle	0	N_hadrons	{num_outputs}\n"
+            event_info = f"#	Event	{event_number+1}	weight	1	EPangle	0	N_hadrons	{num_outputs}\n"
             f.write(event_info)
 
             # Write particle data line with white space separation
@@ -121,6 +122,146 @@ def test_num_output_per_event(jetscape_file_path):
 def test_num_events(jetscape_file_path):
     jetscape = Jetscape(jetscape_file_path)
     assert jetscape.num_events() == 5
+
+def test_set_num_events(tmp_path):
+    number_of_events = [1, 3, 7, 14, 61, 99]
+
+    # Create multiple temporary Oscar2013 files with different numbers of events
+    for events in number_of_events:
+        tmp_jetscape_file = create_temporary_jetscape_file(tmp_path, events)
+        jetscape = Jetscape(tmp_jetscape_file)
+        assert jetscape.num_events() == events
+        del(jetscape)
+        del(tmp_jetscape_file)
+
+def test_loading_defined_events_and_checking_event_length(tmp_path):
+    # To make sure that the correct number of lines are skipped when loading 
+    # only a subset of events, we create a JETSCAPE file with a known number of 
+    # events and then load a subset of events from it. We then check if the 
+    # number of events loaded is equal to the number of events requested.
+    num_events = 8
+    num_output_per_event = [3, 1, 8, 4, 7, 11, 17, 2]
+    
+    tmp_jetscape_file = create_temporary_jetscape_file(tmp_path, num_events, 
+                                                num_output_per_event)
+    
+    # Single events
+    for event in range(num_events):
+        jetscape = Jetscape(tmp_jetscape_file, events=event)
+        assert jetscape.num_events() == 1
+        assert len(jetscape.particle_objects_list()[0]) == num_output_per_event[event]
+        del(jetscape)
+
+    # Multiple events
+    for event_start in range(num_events):
+        for event_end in range(event_start, num_events):
+            jetscape = Jetscape(tmp_jetscape_file, events=(event_start, event_end))
+
+            assert jetscape.num_events() == event_end - event_start + 1
+
+            for event in range(event_end - event_start + 1):
+                assert len(jetscape.particle_objects_list()[event]) == \
+                       num_output_per_event[event + event_start]
+            del(jetscape)
+
+@pytest.fixture
+def particle_list_strange():
+    particle_list1 = []
+    for _ in range(5):
+        p = Particle()
+        p.pdg = 321
+        particle_list1.append(p)
+    for _ in range(5):
+        p = Particle()
+        p.pdg = 211
+        particle_list1.append(p)
+    particle_list2 = []
+    for _ in range(7):
+        p = Particle()
+        p.pdg = 321
+        particle_list2.append(p)
+    for _ in range(15):
+        p = Particle()
+        p.pdg = 211
+        particle_list2.append(p)
+    return [particle_list1, particle_list2]
+
+def test_filter_strangeness_in_Jetscape(tmp_path,particle_list_strange):
+    tmp_jetscape_file = create_temporary_jetscape_file(tmp_path, 2)
+    jetscape = Jetscape(tmp_jetscape_file)
+    jetscape.particle_list_ = particle_list_strange
+    jetscape.strange_particles()
+
+    assert np.array_equal(jetscape.num_output_per_event(), np.array([[1,5],[2,7]]))
+
+@pytest.fixture
+def particle_list_charge():
+    particle_list1 = []
+    for _ in range(5):
+        p = Particle()
+        p.charge = 1
+        particle_list1.append(p)
+    for _ in range(3):
+        p = Particle()
+        p.charge = 0
+        particle_list1.append(p)
+    particle_list2 = []
+    for _ in range(7):
+        p = Particle()
+        p.charge = 0
+        particle_list2.append(p)
+    for _ in range(15):
+        p = Particle()
+        p.charge = 1
+        particle_list2.append(p)
+    return [particle_list1, particle_list2]
+
+def test_filter_charge_in_Jetscape(tmp_path,particle_list_charge):
+    tmp_jetscape_file = create_temporary_jetscape_file(tmp_path, 2)
+    jetscape1 = Jetscape(tmp_jetscape_file)
+    jetscape2 = Jetscape(tmp_jetscape_file)
+    jetscape1.particle_list_ = particle_list_charge
+    jetscape2.particle_list_ = copy.deepcopy(particle_list_charge)
+    jetscape1.charged_particles()
+    jetscape2.uncharged_particles()
+
+    assert np.array_equal(jetscape1.num_output_per_event(), np.array([[1,5],[2,15]]))
+    assert np.array_equal(jetscape2.num_output_per_event(), np.array([[1,3],[2,7]]))
+
+@pytest.fixture
+def particle_list_pdg():
+    particle_list1 = []
+    for _ in range(5):
+        p = Particle()
+        p.pdg = 211
+        particle_list1.append(p)
+    for _ in range(3):
+        p = Particle()
+        p.pdg = 22
+        particle_list1.append(p)
+    particle_list2 = []
+    for _ in range(7):
+        p = Particle()
+        p.pdg = 22
+        particle_list2.append(p)
+    for _ in range(15):
+        p = Particle()
+        p.pdg = 221
+        particle_list2.append(p)
+    return [particle_list1, particle_list2]
+
+def test_filter_pdg_in_Jetscape(tmp_path,particle_list_pdg):
+    tmp_jetscape_file = create_temporary_jetscape_file(tmp_path, 2)
+    jetscape1 = Jetscape(tmp_jetscape_file)
+    jetscape2 = Jetscape(tmp_jetscape_file)
+    jetscape1.particle_list_ = particle_list_pdg
+    jetscape2.particle_list_ = copy.deepcopy(particle_list_pdg)
+    jetscape1.particle_species([211,221])
+    jetscape2.remove_particle_species(22)
+
+    assert np.array_equal(jetscape1.num_output_per_event(), np.array([[1,5],[2,15]]))
+    assert np.array_equal(jetscape2.num_output_per_event(), np.array([[1,5],[2,15]]))
+
 
 def test_particle_list(jetscape_file_path):
     dummy_particle_list = [[0, 111, 27, 0.138, 0.0, 0.0, 0.0],

--- a/tests/test_Jetscape.py
+++ b/tests/test_Jetscape.py
@@ -113,27 +113,6 @@ def test_Jetscape_initialization(jetscape_file_path):
     jetscape = Jetscape(jetscape_file_path)
     assert jetscape is not None
 
-def test_num_output_per_event(jetscape_file_path):
-    num_output_jetscape = [[1, 25],[2, 41],[3, 46],[4, 43],[5, 45]]
-    
-    jetscape = Jetscape(jetscape_file_path)
-    assert (jetscape.num_output_per_event() == num_output_jetscape).all()
-
-def test_num_events(jetscape_file_path):
-    jetscape = Jetscape(jetscape_file_path)
-    assert jetscape.num_events() == 5
-
-def test_set_num_events(tmp_path):
-    number_of_events = [1, 3, 7, 14, 61, 99]
-
-    # Create multiple temporary Oscar2013 files with different numbers of events
-    for events in number_of_events:
-        tmp_jetscape_file = create_temporary_jetscape_file(tmp_path, events)
-        jetscape = Jetscape(tmp_jetscape_file)
-        assert jetscape.num_events() == events
-        del(jetscape)
-        del(tmp_jetscape_file)
-
 def test_loading_defined_events_and_checking_event_length(tmp_path):
     # To make sure that the correct number of lines are skipped when loading 
     # only a subset of events, we create a JETSCAPE file with a known number of 
@@ -163,6 +142,75 @@ def test_loading_defined_events_and_checking_event_length(tmp_path):
                 assert len(jetscape.particle_objects_list()[event]) == \
                        num_output_per_event[event + event_start]
             del(jetscape)
+
+def test_num_output_per_event(jetscape_file_path):
+    num_output_jetscape = [[1, 25],[2, 41],[3, 46],[4, 43],[5, 45]]
+    
+    jetscape = Jetscape(jetscape_file_path)
+    assert (jetscape.num_output_per_event() == num_output_jetscape).all()
+
+def test_num_events(tmp_path,jetscape_file_path):
+    jetscape = Jetscape(jetscape_file_path)
+    assert jetscape.num_events() == 5
+
+    number_of_events = [1, 5, 17, 3, 44, 101, 98]
+
+    for events in number_of_events:
+        # Create temporary Jetscape files
+        tmp_jetscape_file = create_temporary_jetscape_file(tmp_path, events)
+        jetscape = Jetscape(tmp_jetscape_file)
+        assert jetscape.num_events() == events
+        del(jetscape)
+        del(tmp_jetscape_file)
+
+def test_set_num_events(tmp_path):
+    number_of_events = [1, 3, 7, 14, 61, 99]
+
+    # Create multiple temporary Jetscape files with different numbers of events
+    for events in number_of_events:
+        tmp_jetscape_file = create_temporary_jetscape_file(tmp_path, events)
+        jetscape = Jetscape(tmp_jetscape_file)
+        assert jetscape.num_events() == events
+        del(jetscape)
+        del(tmp_jetscape_file)
+
+def test_particle_list(jetscape_file_path):
+    dummy_particle_list = [[0, 111, 27, 0.138, 0.0, 0.0, 0.0],
+                           [1, 111, 27, 0.138, 0.0, 0.0, 0.0],
+                           [2, 111, 27, 0.138, 0.0, 0.0, 0.0],
+                           [3, 111, 27, 0.138, 0.0, 0.0, 0.0],
+                           [4, 111, 27, 0.138, 0.0, 0.0, 0.0], 
+                           [5, 111, 27, 0.138, 0.0, 0.0, 0.0],
+                           [6, 111, 27, 0.138, 0.0, 0.0, 0.0],
+                           [7, 111, 27, 0.138, 0.0, 0.0, 0.0],
+                           [8, 111, 27, 0.138, 0.0, 0.0, 0.0],
+                           [9, 111, 27, 0.138, 0.0, 0.0, 0.0]]
+    
+    dummy_particle_list_nested = [[[0, 111, 27, 0.138, 0.0, 0.0, 0.0],
+                           [1, 111, 27, 0.138, 0.0, 0.0, 0.0]],
+                           [[2, 111, 27, 0.138, 0.0, 0.0, 0.0],
+                           [3, 111, 27, 0.138, 0.0, 0.0, 0.0]],
+                           [[4, 111, 27, 0.138, 0.0, 0.0, 0.0], 
+                           [5, 111, 27, 0.138, 0.0, 0.0, 0.0]],
+                           [[6, 111, 27, 0.138, 0.0, 0.0, 0.0],
+                           [7, 111, 27, 0.138, 0.0, 0.0, 0.0]],
+                           [[8, 111, 27, 0.138, 0.0, 0.0, 0.0],
+                           [9, 111, 27, 0.138, 0.0, 0.0, 0.0]]]
+    
+    particle_objects = []
+    for particle_data in dummy_particle_list:
+        particle_objects.append(Particle("JETSCAPE", particle_data))
+        
+    # Reshape particle objects list such that we have 5 events with 
+    # 2 particle objects each and turn it back into a python list
+    particle_objects = (np.array(particle_objects).reshape((5, 2))).tolist()
+
+    jetscape = Jetscape(jetscape_file_path)
+    jetscape.particle_list_ = particle_objects
+    jetscape.num_events_ = 5
+    jetscape.num_output_per_event_ = np.array([[0,2],[1,2],[2,2],[3,2],[4,2]])
+    
+    assert (jetscape.particle_list() == dummy_particle_list_nested)
 
 @pytest.fixture
 def particle_list_strange():
@@ -261,45 +309,6 @@ def test_filter_pdg_in_Jetscape(tmp_path,particle_list_pdg):
 
     assert np.array_equal(jetscape1.num_output_per_event(), np.array([[1,5],[2,15]]))
     assert np.array_equal(jetscape2.num_output_per_event(), np.array([[1,5],[2,15]]))
-
-
-def test_particle_list(jetscape_file_path):
-    dummy_particle_list = [[0, 111, 27, 0.138, 0.0, 0.0, 0.0],
-                           [1, 111, 27, 0.138, 0.0, 0.0, 0.0],
-                           [2, 111, 27, 0.138, 0.0, 0.0, 0.0],
-                           [3, 111, 27, 0.138, 0.0, 0.0, 0.0],
-                           [4, 111, 27, 0.138, 0.0, 0.0, 0.0], 
-                           [5, 111, 27, 0.138, 0.0, 0.0, 0.0],
-                           [6, 111, 27, 0.138, 0.0, 0.0, 0.0],
-                           [7, 111, 27, 0.138, 0.0, 0.0, 0.0],
-                           [8, 111, 27, 0.138, 0.0, 0.0, 0.0],
-                           [9, 111, 27, 0.138, 0.0, 0.0, 0.0]]
-    
-    dummy_particle_list_nested = [[[0, 111, 27, 0.138, 0.0, 0.0, 0.0],
-                           [1, 111, 27, 0.138, 0.0, 0.0, 0.0]],
-                           [[2, 111, 27, 0.138, 0.0, 0.0, 0.0],
-                           [3, 111, 27, 0.138, 0.0, 0.0, 0.0]],
-                           [[4, 111, 27, 0.138, 0.0, 0.0, 0.0], 
-                           [5, 111, 27, 0.138, 0.0, 0.0, 0.0]],
-                           [[6, 111, 27, 0.138, 0.0, 0.0, 0.0],
-                           [7, 111, 27, 0.138, 0.0, 0.0, 0.0]],
-                           [[8, 111, 27, 0.138, 0.0, 0.0, 0.0],
-                           [9, 111, 27, 0.138, 0.0, 0.0, 0.0]]]
-    
-    particle_objects = []
-    for particle_data in dummy_particle_list:
-        particle_objects.append(Particle("JETSCAPE", particle_data))
-        
-    # Reshape particle objects list such that we have 5 events with 
-    # 2 particle objects each and turn it back into a python list
-    particle_objects = (np.array(particle_objects).reshape((5, 2))).tolist()
-
-    jetscape = Jetscape(jetscape_file_path)
-    jetscape.particle_list_ = particle_objects
-    jetscape.num_events_ = 5
-    jetscape.num_output_per_event_ = np.array([[0,2],[1,2],[2,2],[3,2],[4,2]])
-    
-    assert (jetscape.particle_list() == dummy_particle_list_nested)
 
 def test_Jetscape_print(jetscape_file_path, output_path):
     jetscape = Jetscape(jetscape_file_path)

--- a/tests/test_Oscar.py
+++ b/tests/test_Oscar.py
@@ -173,7 +173,6 @@ def test_loading_defined_events_and_checking_event_length(tmp_path):
             assert oscar.num_events() == event_end - event_start + 1
 
             for event in range(event_end - event_start + 1):
-                print(event)
                 assert len(oscar.particle_objects_list()[event]) == \
                        num_output_per_event[event + event_start]
             del(oscar)
@@ -214,9 +213,6 @@ def test_filter_in_oscar(tmp_path):
     oscar2.particle_list_ = copy.deepcopy(particle_objects)
     oscar1.charged_particles()
     oscar2.uncharged_particles()
-    print(oscar2.num_output_per_event())
-    
-    print("Pi0 charge: ", pi_0_participant.charge)
 
     assert np.array_equal(oscar1.num_output_per_event(), np.array([[0, 6],[1, 10]]))
     assert np.array_equal(oscar2.num_output_per_event(), np.array([[0, 6],[1, 20]]))


### PR DESCRIPTION
This adds the missing tests to the Jetscape tests.

@nilssass I chose to do it with the pytest fixtures for the particle lists, this is a bit cleaner. You can copy this for the Oscar tests if you want. 