### PR TITLE
Make POI for differential flow truly optional 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Date: 2024-05-08
 
 ### Fixed
 * Jetscape: Fix for Jetscape charged particle filtering
+* QCumulantFlow and LeeYangZeroFlow: Fix bug in the calculation of the differential flow
 
 [Link to diff from previous version](https://github.com/smash-transport/sparkx/compare/v1.2.0...v1.2.1)
 

--- a/src/sparkx/flow/LeeYangZeroFlow.py
+++ b/src/sparkx/flow/LeeYangZeroFlow.py
@@ -568,8 +568,9 @@ class LeeYangZeroFlow(FlowInterface.FlowInterface):
                         val = particle.momentum_rapidity_Y()
                     elif flow_as_function_of == "pseudorapidity":
                         val = particle.pseudorapidity()
-                    if val >= bins[bin] and val < bins[bin+1] and particle.pdg in poi_pdg:
-                        particles_event.append(particle)
+                    if val >= bins[bin] and val < bins[bin+1]:
+                        if poi_pdg == None or particle.pdg in poi_pdg:
+                            particles_event.append(particle)
                 if len(particles_event) > 0:
                     events_bin.extend([particles_event])
             particle_data_bin.extend([events_bin])

--- a/src/sparkx/flow/QCumulantFlow.py
+++ b/src/sparkx/flow/QCumulantFlow.py
@@ -773,7 +773,7 @@ class QCumulantFlow(FlowInterface.FlowInterface):
                         val = particle.pseudorapidity()
                     if val >= bins[bin] and val < bins[bin+1]:
                         particles_event.append(particle.phi()+self.rand_reaction_planes_[event])
-                        if particle.pdg in poi_pdg:
+                        if poi_pdg == None or particle.pdg in poi_pdg:
                             particles_event_poi.append(particle.phi()+self.rand_reaction_planes_[event])
                 events_bin.extend([particles_event])
                 events_bin_poi.extend([particles_event_poi])


### PR DESCRIPTION
A bug prevented execution when POI_PDG was None.