### PR TITLE
Sass/add mT to particle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ The main categories for changes in this file are:
 
 A `Deprecated` section could be added if needed for soon-to-be removed features.
 
+## v.2.0.0
+Date:
+
+### Added
+* Particle: Add member function to calculate the transverse mass of a particle
+
 ## v1.3.0-Newton
 Date: 2024-07-25
 

--- a/docs/source/classes/Particle/index.rst
+++ b/docs/source/classes/Particle/index.rst
@@ -18,6 +18,7 @@ Particle
 .. automethod:: Particle.proper_time
 .. automethod:: Particle.compute_mass_from_energy_momentum
 .. automethod:: Particle.compute_charge_from_pdg
+.. automethod:: Particle.mT
 .. automethod:: Particle.is_meson
 .. automethod:: Particle.is_baryon
 .. automethod:: Particle.is_hadron

--- a/src/sparkx/Particle.py
+++ b/src/sparkx/Particle.py
@@ -149,6 +149,8 @@ class Particle:
         Compute mass from energy momentum relation
     compute_charge_from_pdg:
         Compute charge from PDG code
+    mT:
+        Compute transverse mass
     is_meson:
         Is the particle a meson?
     is_baryon:
@@ -1075,6 +1077,25 @@ class Particle:
         if not self.pdg_valid:
             return np.nan
         return PDGID(self.pdg).charge
+
+    def mT(self):
+        """
+        Compute the transverse mass :math:`m_{T}=\\sqrt{m^2-p_z^2}` of the particle.
+
+        Returns
+        -------
+        float
+            transverse mass
+
+        Notes
+        -----
+        If one of the needed particle quantities is not given, then `np.nan`
+        is returned.
+        """
+        if np.isnan(self.mass) or np.isnan(self.pz):
+            return np.nan
+        else:
+            return np.sqrt(self.mass**2. - self.pz**2.)
 
     def is_meson(self):
         """


### PR DESCRIPTION
This PR adds transverse mass as a member function to Particle. Besides the general use case, we need the transverse mass for the new BulkObservables class.