### PR TITLE
Add Storer objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Date:
 * Added ParticleObjectStorer to store generic particle lists
 * SPARKX checks now for static tying consistency
 * Added support for the SMASH 3.2 feature of ASCIICustom output format
+* Add option to add two Oscar/Jetscape/ParticleObjectStorer instances while preserving the event order
 
 ### Changed
 * Particle: Rename several methods for a more intuitive naming scheme. Renamed methods are:

--- a/src/sparkx/BaseStorer.py
+++ b/src/sparkx/BaseStorer.py
@@ -159,12 +159,37 @@ class BaseStorer(ABC):
         combined_num_output_per_event[self.num_events_:, 0] += self.num_events_
 
         combined_storer: BaseStorer = self.__class__.__new__(self.__class__)
+        combined_storer._update_after_merge(other)
         combined_storer.particle_list_ = combined_particle_list
         combined_storer.num_output_per_event_ = combined_num_output_per_event
         combined_storer.num_events_ = self.num_events_ + other.num_events_
         combined_storer.loader_ = None  # Loader is not applicable for combined object
 
         return combined_storer
+    
+    @abstractmethod
+    def _update_after_merge(self, other: "BaseStorer") -> None:
+        """
+        Updates the attributes of the current instance after merging with another BaseStorer object.
+
+        This method should be implemented by subclasses to update the attributes of the current instance after merging
+        with another BaseStorer object. The method raises a NotImplementedError if it is not overridden by a subclass.
+
+        Parameters
+        ----------
+        other : BaseStorer
+            The other BaseStorer object that was merged with the current instance.
+
+        Raises
+        ------
+        NotImplementedError
+            If the method is not implemented by a subclass.
+
+        Returns
+        -------
+        None
+        """
+        raise NotImplementedError("This method is not implemented yet")
 
     @abstractmethod
     def create_loader(self, arg: Union[str, List[List["Particle"]]]) -> None:

--- a/src/sparkx/BaseStorer.py
+++ b/src/sparkx/BaseStorer.py
@@ -159,6 +159,7 @@ class BaseStorer(ABC):
         combined_num_output_per_event[self.num_events_:, 0] += self.num_events_
 
         combined_storer: BaseStorer = self.__class__.__new__(self.__class__)
+        combined_storer.__dict__.update(self.__dict__)  # Inherit all properties from self
         combined_storer._update_after_merge(other)
         combined_storer.particle_list_ = combined_particle_list
         combined_storer.num_output_per_event_ = combined_num_output_per_event

--- a/src/sparkx/BaseStorer.py
+++ b/src/sparkx/BaseStorer.py
@@ -109,6 +109,62 @@ class BaseStorer(ABC):
             ) = self.loader_.load(**kwargs)
         else:
             raise ValueError("Loader has not been created properly")
+        
+    def __add__(self, other: "BaseStorer") -> "BaseStorer":
+        """
+        Adds two BaseStorer objects by combining their particle lists and updating num_output_per_event accordingly.
+
+        This method ensures that both objects are instances of the same class before combining them. If the objects
+        are not of the same class, a TypeError is raised.
+
+        Parameters
+        ----------
+        other : BaseStorer
+            The other BaseStorer object to be added.
+
+        Raises
+        ------
+        TypeError
+            If the other object is not an instance of BaseStorer or if the objects are not of the same class.
+
+        Returns
+        -------
+        BaseStorer
+            A new BaseStorer object with combined particle lists and updated num_output_per_event.
+        """
+        if not isinstance(other, BaseStorer):
+            raise TypeError("Can only add BaseStorer objects")
+        
+        # Ensure that both instances are of the same class
+        if type(self) is not type(other):
+            raise TypeError("Can only add objects of the same class")
+
+        combined_particle_list: list = self.particle_list_ + other.particle_list_
+
+        # Ensure num_output_per_event_ is not None
+        if self.num_output_per_event_ is None:
+            self.num_output_per_event_ = np.empty((0, 2), dtype=int)
+        if other.num_output_per_event_ is None:
+            other.num_output_per_event_ = np.empty((0, 2), dtype=int)
+        if self.num_events_ is None:
+            self.num_events_ = 0
+        if other.num_events_ is None:
+            other.num_events_ = 0
+
+        combined_num_output_per_event: np.ndarray = np.concatenate(
+            (self.num_output_per_event_, other.num_output_per_event_)
+        )
+
+        # Adjust event_number for the parts that originally belonged to other
+        combined_num_output_per_event[self.num_events_:, 0] += self.num_events_
+
+        combined_storer: BaseStorer = self.__class__.__new__(self.__class__)
+        combined_storer.particle_list_ = combined_particle_list
+        combined_storer.num_output_per_event_ = combined_num_output_per_event
+        combined_storer.num_events_ = self.num_events_ + other.num_events_
+        combined_storer.loader_ = None  # Loader is not applicable for combined object
+
+        return combined_storer
 
     @abstractmethod
     def create_loader(self, arg: Union[str, List[List["Particle"]]]) -> None:

--- a/src/sparkx/Jetscape.py
+++ b/src/sparkx/Jetscape.py
@@ -229,7 +229,8 @@ class Jetscape(BaseStorer):
 
         This method is called after merging two Jetscape instances to update the
         attributes of the current instance based on the attributes of the other instance.
-        The last line, filename and :code:`sigmaGen` are taken from the left-hand instance.
+        The last line and filename are taken from the left-hand instance.
+        :code:`sigmaGen` is averaged.
 
         Parameters
         ----------
@@ -244,9 +245,11 @@ class Jetscape(BaseStorer):
         if not isinstance(other, Jetscape):
             raise TypeError("Can only add Jetscape objects to Jetscape.")
         if self.particle_type_ != other.particle_type_:
-            warnings.warn("particle_types of the merged instances do not match. Taking the left-hand side particle type.")
+            raise TypeError("particle_types of the merged instances do not match.")
         if self.particle_type_defining_string_ != other.particle_type_defining_string_:
-            warnings.warn("particle_type_defining_string of the merged instances do not match. Taking the left-hand side particle type defining string.")
+            raise TypeError("particle_type_defining_string of the merged instances do not match.")
+        
+        self.sigmaGen_ = ((self.sigmaGen_[0] + other.sigmaGen_[0])/2.0, 0.5*np.sqrt(self.sigmaGen_[1]**2 + other.sigmaGen_[1]**2))
     
     # PUBLIC CLASS METHODS
     def participants(self) -> "Jetscape":

--- a/src/sparkx/Jetscape.py
+++ b/src/sparkx/Jetscape.py
@@ -222,7 +222,32 @@ class Jetscape(BaseStorer):
         particle_list[6] = float(particle.pz)
 
         return particle_list
+    
+    def _update_after_merge(self, other: BaseStorer) -> None:
+        """
+        Updates the current instance after merging with another Jetscape instance.
 
+        This method is called after merging two Jetscape instances to update the
+        attributes of the current instance based on the attributes of the other instance.
+        The last line, filename and :code:`sigmaGen` are taken from the left-hand instance.
+
+        Parameters
+        ----------
+        other : Jetscape
+            The other Jetscape instance that was merged with the current instance.
+
+        Raises
+        ------
+        UserWarning
+            If the Jetscape :code:`particle_type_` or :code:`particle_type_defining_string_` of the two instances do not match, a warning is issued.
+        """
+        if not isinstance(other, Jetscape):
+            raise TypeError("Can only add Jetscape objects to Jetscape.")
+        if self.particle_type_ != other.particle_type_:
+            warnings.warn("particle_types of the merged instances do not match. Taking the left-hand side particle type.")
+        if self.particle_type_defining_string_ != other.particle_type_defining_string_:
+            warnings.warn("particle_type_defining_string of the merged instances do not match. Taking the left-hand side particle type defining string.")
+    
     # PUBLIC CLASS METHODS
     def participants(self) -> "Jetscape":
         """

--- a/src/sparkx/Oscar.py
+++ b/src/sparkx/Oscar.py
@@ -275,6 +275,29 @@ class Oscar(BaseStorer):
         raise NotImplementedError(
             "keep_quarks is not implemented for the Oscar class."
         )
+    
+    def _update_after_merge(self, other: BaseStorer) -> None:
+        """
+        Updates the current instance after merging with another Oscar instance.
+
+        This method is called after merging two Oscar instances to update the
+        attributes of the current instance based on the attributes of the other instance.
+
+        Parameters
+        ----------
+        other : Oscar
+            The other Oscar instance that was merged with the current instance.
+
+        Raises
+        ------
+        UserWarning
+            If the Oscar formats of the two instances do not match, a warning is issued.
+        """
+        if not isinstance(other, Oscar):
+            raise TypeError("Can only add Oscar objects to Oscar.")
+        if self.oscar_format_ != other.oscar_format_:
+            warnings.warn("Oscar format of the merged instances do not match. Taking the left-hand side Oscar format.")
+        self.event_end_lines_ = self.event_end_lines_ + other.event_end_lines_
 
     def oscar_format(self) -> Union[str, None]:
         """

--- a/src/sparkx/Particle.py
+++ b/src/sparkx/Particle.py
@@ -499,7 +499,7 @@ class Particle:
         if not self.pdg_valid:
             if np.isnan(self.pdg):
                 warnings.warn(
-                "No PDG code given!"
+                "No PDG code given! "
                 + "All properties extracted from the PDG are set to default values."
             )
             else:

--- a/src/sparkx/ParticleObjectStorer.py
+++ b/src/sparkx/ParticleObjectStorer.py
@@ -134,6 +134,9 @@ class ParticleObjectStorer(BaseStorer):
         super().__init__(particle_object_list, **kwargs)
         del self.loader_
 
+    def _update_after_merge(self, other: BaseStorer) -> None:
+        pass
+
     def create_loader(
         self, particle_object_list: Union[str, List[List["Particle"]]]
     ) -> None:

--- a/tests/test_BaseStorer.py
+++ b/tests/test_BaseStorer.py
@@ -44,6 +44,10 @@ class ConcreteStorer(BaseStorer):
                 file.write(str(event) + "\n")
 
 
+class ConcreteStorer2(ConcreteStorer):
+    pass
+
+
 # Fixtures for creating instances
 @pytest.fixture
 def concrete_storer():
@@ -104,3 +108,67 @@ def test_print_particle_lists_to_file(concrete_storer, tmp_path):
     with open(output_file, "r") as f:
         content = f.read()
     assert content == "[1, 2, 3]\n[4, 5, 6]\n"
+
+def test_add_storer():
+    storer1 = ConcreteStorer(path="dummy_path")
+    storer2 = ConcreteStorer(path="dummy_path")
+    storer3 = ConcreteStorer2(path="dummy_path")
+
+    # Mock data for storer1
+    storer1.particle_list_ = [
+        [[1, 2, 3], [4, 5, 6]],
+        [[7, 8, 9], [10, 11, 12]],
+        [[7, 8, 9], [10, 11, 12], [10, 11, 12]]
+    ]
+    storer1.num_output_per_event_ = np.array([[1, 2], [2, 2], [3, 3]])
+    storer1.num_events_ = 3
+
+    # Mock data for storer2
+    storer2.particle_list_ = [
+        [[13, 14, 15]],
+        [[19, 20, 21], [22, 23, 24]]
+    ]
+    storer2.num_output_per_event_ = np.array([[1, 1], [2, 2]])
+    storer2.num_events_ = 2
+
+    # Add the two storers
+    combined_storer = storer1 + storer2
+
+    # Expected combined data
+    expected_particle_list = [
+        [[1, 2, 3], [4, 5, 6]],
+        [[7, 8, 9], [10, 11, 12]],
+        [[7, 8, 9], [10, 11, 12], [10, 11, 12]],
+        [[13, 14, 15]],
+        [[19, 20, 21], [22, 23, 24]]
+    ]
+    expected_num_output_per_event = np.array([[1, 2], [2, 2],[3, 3], [4, 1], [5, 2]])
+    expected_num_events = 5
+
+     # Add the two storers
+    combined_storer2 = storer2 + storer1
+
+    # Expected combined data
+    expected_particle_list2 = [
+        [[13, 14, 15]],
+        [[19, 20, 21], [22, 23, 24]],
+        [[1, 2, 3], [4, 5, 6]],
+        [[7, 8, 9], [10, 11, 12]],
+        [[7, 8, 9], [10, 11, 12], [10, 11, 12]]
+    ]
+    expected_num_output_per_event2 = np.array([[1, 1], [2, 2],[3, 2], [4, 2], [5, 3]])
+    expected_num_events2 = 5
+
+    # Assertions
+    assert combined_storer.particle_list_ == expected_particle_list
+    assert np.array_equal(combined_storer.num_output_per_event_, expected_num_output_per_event)
+    assert combined_storer.num_events_ == expected_num_events
+    assert combined_storer2.particle_list_ == expected_particle_list2
+    assert np.array_equal(combined_storer2.num_output_per_event_, expected_num_output_per_event2)
+    assert combined_storer2.num_events_ == expected_num_events2
+
+    with pytest.raises(TypeError):
+        storer1 + 1
+    
+    with pytest.raises(TypeError):
+        storer1 + storer3

--- a/tests/test_BaseStorer.py
+++ b/tests/test_BaseStorer.py
@@ -42,7 +42,9 @@ class ConcreteStorer(BaseStorer):
         with open(output_file, "w") as file:
             for event in self.particle_list():
                 file.write(str(event) + "\n")
-
+    
+    def _update_after_merge(self, other: "ConcreteStorer") -> None:
+        pass
 
 class ConcreteStorer2(ConcreteStorer):
     pass

--- a/tests/test_Jetscape.py
+++ b/tests/test_Jetscape.py
@@ -499,3 +499,24 @@ def test_Jetscape_read_parton_file(jetscape_file_path_partons):
     # Test construction with wrong particletype (not string)
     with pytest.raises(TypeError):
         Jetscape(jetscape_file_path_partons, particletype=1)
+
+def test_update_after_merge_warning(jetscape_file_path):
+    # Create two Jetscape instances with different particle types and defining strings
+    jetscape1 = Jetscape(jetscape_file_path)
+    jetscape1.particle_type_ = "type1"
+    jetscape1.particle_type_defining_string_ = "string1"
+
+    jetscape2 = Jetscape(jetscape_file_path)
+    jetscape2.particle_type_ = "type2"
+    jetscape2.particle_type_defining_string_ = "string2"
+
+    # Check if a UserWarning is issued when merging
+    with pytest.warns(UserWarning, match="particle_types of the merged instances do not match. Taking the left-hand side particle type."):
+        jetscape1._update_after_merge(jetscape2)
+
+    with pytest.warns(UserWarning, match="particle_type_defining_string of the merged instances do not match. Taking the left-hand side particle type defining string."):
+        jetscape1._update_after_merge(jetscape2)
+
+    # Check if the attributes are updated correctly
+    assert jetscape1.particle_type_ == "type1"
+    assert jetscape1.particle_type_defining_string_ == "string1"

--- a/tests/test_Jetscape.py
+++ b/tests/test_Jetscape.py
@@ -503,20 +503,25 @@ def test_Jetscape_read_parton_file(jetscape_file_path_partons):
 def test_update_after_merge_warning(jetscape_file_path):
     # Create two Jetscape instances with different particle types and defining strings
     jetscape1 = Jetscape(jetscape_file_path)
-    jetscape1.particle_type_ = "type1"
-    jetscape1.particle_type_defining_string_ = "string1"
+    jetscape1.particle_type_ = "parton"
+    jetscape1.particle_type_defining_string_ = "parton"
+    jetscape1.sigmaGen_ = (1,2)
 
     jetscape2 = Jetscape(jetscape_file_path)
-    jetscape2.particle_type_ = "type2"
-    jetscape2.particle_type_defining_string_ = "string2"
+    jetscape2.particle_type_ = "hadron"
+    jetscape2.particle_type_defining_string_ = "hadron"
+    jetscape2.sigmaGen_ = (2,2)
 
     # Check if a UserWarning is issued when merging
-    with pytest.warns(UserWarning, match="particle_types of the merged instances do not match. Taking the left-hand side particle type."):
+    with pytest.raises(TypeError):
         jetscape1._update_after_merge(jetscape2)
 
-    with pytest.warns(UserWarning, match="particle_type_defining_string of the merged instances do not match. Taking the left-hand side particle type defining string."):
+    with pytest.raises(TypeError):
         jetscape1._update_after_merge(jetscape2)
 
-    # Check if the attributes are updated correctly
-    assert jetscape1.particle_type_ == "type1"
-    assert jetscape1.particle_type_defining_string_ == "string1"
+    jetscape2.particle_type_ = "parton"
+    jetscape2.particle_type_defining_string_ = "parton"
+
+    jetscape1._update_after_merge(jetscape2)
+
+    assert jetscape1.sigmaGen_ == (1.5,np.sqrt(2))

--- a/tests/test_Oscar.py
+++ b/tests/test_Oscar.py
@@ -716,3 +716,20 @@ def test_custom_oscar_print(oscar_custom_file_path, output_path):
     oscar.print_particle_lists_to_file(output_path)
     assert filecmp.cmp(oscar_custom_file_path, output_path)
     os.remove(output_path)
+def test_update_after_merge_warning(oscar_file_path):
+    # Create two Oscar instances with different formats
+    oscar1 = Oscar(oscar_file_path)
+    oscar1.oscar_format_ = "Oscar2013"
+    oscar1.event_end_lines_ = [10, 20, 30]
+
+    oscar2 = Oscar(oscar_file_path)
+    oscar2.oscar_format_ = "Oscar2013Extended"
+    oscar2.event_end_lines_ = [40, 50, 60]
+
+    # Check if a UserWarning is issued when merging
+    with pytest.warns(UserWarning, match="Oscar format of the merged instances do not match"):
+        oscar1._update_after_merge(oscar2)
+
+    # Check if the event_end_lines_ are updated correctly
+    assert oscar1.event_end_lines_ == [10, 20, 30, 40, 50, 60]
+

--- a/tests/test_Oscar.py
+++ b/tests/test_Oscar.py
@@ -712,10 +712,12 @@ def test_old_extended_oscar_print(oscar_old_extended_file_path, output_path):
 
 
 def test_custom_oscar_print(oscar_custom_file_path, output_path):
-    oscar = Oscar(oscar_custom_file_path)
+    with pytest.warns(UserWarning, match="No PDG code given! All properties extracted from the PDG are set to default values."):
+        oscar = Oscar(oscar_custom_file_path)
     oscar.print_particle_lists_to_file(output_path)
     assert filecmp.cmp(oscar_custom_file_path, output_path)
     os.remove(output_path)
+
 def test_update_after_merge_warning(oscar_file_path):
     # Create two Oscar instances with different formats
     oscar1 = Oscar(oscar_file_path)


### PR DESCRIPTION
This implements #271 .
Storer objects of the same class can be added now. They take properties of the left-hand-side object. If there are conflicts of properties, a warning is given.