### PR TITLE
Filter out empty events

### DIFF
--- a/src/sparkx/BaseStorer.py
+++ b/src/sparkx/BaseStorer.py
@@ -860,6 +860,8 @@ class BaseStorer(ABC):
             raise ValueError(
                 "num_output_per_event_ has an unexpected number of dimensions"
             )
+        if self.particle_list_ == []:
+            self.particle_list_ = [[]]
 
     @abstractmethod
     def print_particle_lists_to_file(self, output_file: str) -> None:

--- a/src/sparkx/Filter.py
+++ b/src/sparkx/Filter.py
@@ -861,11 +861,12 @@ def multiplicity_cut(
     idx_keep_event = []
     for idx, event_particles in enumerate(particle_list):
         multiplicity = len(event_particles)
-        if multiplicity >= lower_cut and multiplicity < upper_cut:
+        if multiplicity >= lim_min and multiplicity < lim_max:
             idx_keep_event.append(idx)
 
     particle_list = [particle_list[idx] for idx in idx_keep_event]
-
+    if len(particle_list) == 0:
+        particle_list = [[]]
     return particle_list
 
 

--- a/src/sparkx/Jetscape.py
+++ b/src/sparkx/Jetscape.py
@@ -361,9 +361,8 @@ class Jetscape(BaseStorer):
             raise ValueError("The particle list is empty.")
         if self.num_output_per_event_ is None:
             raise ValueError("The number of output per event is empty.")
-        if self.num_events_ is None:
-            raise ValueError("The number of events is empty.")
-        
+        if self.num_events_ == 1 and self.particle_list_ == [[]]:
+                warnings.warn("The number of events is zero.")
         # Open the output file with buffered writing (25 MB)
         with open(output_file, "w", buffering=25 * 1024 * 1024) as f_out:
             f_out.write(header_file)
@@ -371,6 +370,8 @@ class Jetscape(BaseStorer):
             list_of_particles = self.particle_list()
             if self.num_events_ == 0:
                 warnings.warn("The number of events is zero.")
+            elif self.num_events_ is None:
+                warnings.warn("The number of events is None.")
             elif self.num_events_ > 1:
                 for i in range(self.num_events_):
                     event = self.num_output_per_event_[i, 0]

--- a/src/sparkx/Oscar.py
+++ b/src/sparkx/Oscar.py
@@ -388,7 +388,7 @@ class Oscar(BaseStorer):
                 raise ValueError("The number of output per event is empty.")
             if self.num_events_ is None:
                 raise ValueError("The number of events is empty.")
-            if self.num_events_ == 0:
+            if self.num_events_ == 1 and self.particle_list_ == [[]]:
                 warnings.warn("The number of events is zero.")
             elif self.num_events_ > 1:
                 for i in range(self.num_events_):

--- a/src/sparkx/loader/JetscapeLoader.py
+++ b/src/sparkx/loader/JetscapeLoader.py
@@ -421,6 +421,7 @@ class JetscapeLoader(BaseLoader):
         particle_list: List[List[Particle]] = []
         data: List[Particle] = []
         num_read_lines = self.__get_num_read_lines()
+        cut_events=0
         with open(self.PATH_JETSCAPE_, "r") as jetscape_file:
             self._skip_lines(jetscape_file)
 
@@ -429,15 +430,26 @@ class JetscapeLoader(BaseLoader):
                 if not line:
                     raise IndexError("Index out of range of JETSCAPE file")
                 elif "#" in line and "sigmaGen" in line:
+                    old_data_len=len(data)
                     if "filters" in self.optional_arguments_.keys():
                         data = self.__apply_kwargs_filters(
                             [data], kwargs["filters"]
                         )[0]
-                        self.num_output_per_event_[len(particle_list)] = (
-                            len(particle_list) + 1,
-                            len(data),
-                        )
-                    particle_list.append(data)
+                        if (len(data) != 0 or old_data_len==0):
+                            self.num_output_per_event_[len(particle_list)] = (
+                                len(particle_list)+1,
+                                len(data),
+                            )
+                        else:
+                            self.num_output_per_event_ = np.atleast_2d(np.delete(self.num_output_per_event_, len(particle_list), axis=0))                  
+                            if self.num_output_per_event_.shape[0] == 0:
+                                self.num_output_per_event_ = np.array([])
+                            elif len(particle_list) < self.num_output_per_event_.shape[0]:
+                                self.num_output_per_event_[len(particle_list):, 0] -= 1
+                    if (len(data) != 0 or old_data_len==0 ):
+                        particle_list.append(data)
+                    else:
+                        cut_events = cut_events + 1
                 elif i == 0 and "#" not in line and "weight" not in line:
                     raise ValueError(
                         "First line of the event is not a comment "
@@ -463,15 +475,26 @@ class JetscapeLoader(BaseLoader):
                     if int(line_list[2]) == first_event_header:
                         continue
                     else:
+                        old_data_len=len(data)
                         if "filters" in self.optional_arguments_.keys():
                             data = self.__apply_kwargs_filters(
                                 [data], kwargs["filters"]
                             )[0]
-                            self.num_output_per_event_[len(particle_list)] = (
-                                len(particle_list) + 1,
-                                len(data),
-                            )
-                        particle_list.append(data)
+                            if (len(data) != 0 or old_data_len==0):
+                                self.num_output_per_event_[len(particle_list)] = (
+                                    len(particle_list)+1,
+                                    len(data),
+                                )
+                            else:
+                                self.num_output_per_event_ = np.atleast_2d(np.delete(self.num_output_per_event_, len(particle_list), axis=0))                  
+                                if self.num_output_per_event_.shape[0] == 0:
+                                    self.num_output_per_event_ = np.array([])
+                                elif len(particle_list) < self.num_output_per_event_.shape[0]:
+                                    self.num_output_per_event_[len(particle_list):, 0] -= 1
+                        if (len(data) != 0 or old_data_len==0 ):
+                            particle_list.append(data)
+                        else:
+                            cut_events = cut_events + 1
                         data = []
                 else:
                     line_list = (
@@ -479,7 +502,8 @@ class JetscapeLoader(BaseLoader):
                     )
                     particle = Particle("JETSCAPE", np.asarray(line_list))
                     data.append(particle)
-
+        
+        self.num_events_=self.num_events_-cut_events
         # Correct num_output_per_event and num_events
         if not kwargs or "events" not in self.optional_arguments_.keys():
             if len(particle_list) != self.num_events_:
@@ -498,6 +522,9 @@ class JetscapeLoader(BaseLoader):
             update = self.num_output_per_event_[event_start : event_end + 1]
             self.num_output_per_event_ = update
             self.num_events_ = int(event_end - event_start + 1)
+
+        if particle_list == []:
+            particle_list = [[]]
 
         return particle_list
 

--- a/tests/test_Filter.py
+++ b/tests/test_Filter.py
@@ -776,8 +776,11 @@ def test_multiplicity_cut(particle_list_multiplicity):
     assert multiplicity_cut(particle_list_multiplicity, (5,10)) == [
         particle_list_multiplicity[0]
     ]
-    assert multiplicity_cut(particle_list_multiplicity, (11, None)) == []
+    assert multiplicity_cut(particle_list_multiplicity, (11, None)) == [[]]
 
+    assert multiplicity_cut(particle_list_multiplicity, (10, 5))== [
+        particle_list_multiplicity[0]
+    ]
     # Test cases for invalid input
     with pytest.raises(TypeError):
         multiplicity_cut(particle_list_multiplicity, cut_value=(-3.5,4))

--- a/tests/test_Jetscape.py
+++ b/tests/test_Jetscape.py
@@ -324,7 +324,6 @@ def test_filter_rapidity_in_Jetscape_constructor(tmp_path, jetscape_file_path):
     # In this test we test the integration of filters in the Jetscape constructor,
     # which are selected with keyword arguments while initializing the
     # Jetscape object.
-    print("Ahoi")
     pi0_y0 = (0, 111, 27, 0.138, 0.0, 0.0, 0.0)
     pi0_y1 = (1, 111, 27, 0.138, 0.0, 0.0, 0.10510)
 

--- a/tests/test_Jetscape.py
+++ b/tests/test_Jetscape.py
@@ -324,7 +324,7 @@ def test_filter_rapidity_in_Jetscape_constructor(tmp_path, jetscape_file_path):
     # In this test we test the integration of filters in the Jetscape constructor,
     # which are selected with keyword arguments while initializing the
     # Jetscape object.
-
+    print("Ahoi")
     pi0_y0 = (0, 111, 27, 0.138, 0.0, 0.0, 0.0)
     pi0_y1 = (1, 111, 27, 0.138, 0.0, 0.0, 0.10510)
 
@@ -360,16 +360,24 @@ def test_filter_rapidity_in_Jetscape_constructor(tmp_path, jetscape_file_path):
     )
 
 
-def test_filter_status_in_Jetscape_constructor(jetscape_file_path):
+def test_filter_in_Jetscape_constructor(jetscape_file_path):
     # Perform status filtering such that everything should be filtered out with
     # the given jetscape events in the file.
     jetscape1 = Jetscape(jetscape_file_path, filters={"particle_status": 1})
 
-    assert jetscape1.num_events() == 5
+    assert jetscape1.num_events() == 0
     assert np.array_equal(
         jetscape1.num_output_per_event(),
-        np.array([[1, 0], [2, 0], [3, 0], [4, 0], [5, 0]]),
+        np.array([]),
     )
+    jetscape_empty_multiplicity = Jetscape(
+        jetscape_file_path, filters={"multiplicity_cut": (99999999,None)}
+    )
+    print( jetscape_empty_multiplicity.num_output_per_event())
+    assert np.array_equal(
+        jetscape_empty_multiplicity.num_output_per_event(), np.array([])
+    )
+    del jetscape_empty_multiplicity, jetscape1
 
 
 @pytest.fixture
@@ -474,9 +482,7 @@ def test_Jetscape_print_with_empty_events(
 def test_Jetscape_print_with_no_events(
         jetscape_file_path, output_path
 ):
-    jetscape = Jetscape(jetscape_file_path)
-    jetscape.particle_list_ = [[], [], [], [], []]
-    jetscape.multiplicity_cut((100000000,None))
+    jetscape = Jetscape(jetscape_file_path).multiplicity_cut((100000000,None))
     with pytest.warns(UserWarning):
         jetscape.print_particle_lists_to_file(output_path)
     os.remove(output_path)

--- a/tests/test_Oscar.py
+++ b/tests/test_Oscar.py
@@ -595,8 +595,11 @@ def test_filter_in_oscar_constructor(tmp_path):
     oscar_charged_participants = Oscar(
         oscar_file, filters={"charged_particles": True, "participants": True}
     )
-    oscar_uncharged_specators = Oscar(
+    oscar_uncharged_spectators = Oscar(
         oscar_file, filters={"uncharged_particles": True, "spectators": True}
+    )
+    oscar_empty_multiplicity = Oscar(
+        oscar_file, filters={"multiplicity_cut": (99999999,None)}
     )
 
     assert np.array_equal(
@@ -606,17 +609,20 @@ def test_filter_in_oscar_constructor(tmp_path):
         oscar_uncharged.num_output_per_event(), np.array([[0, 18], [1, 20]])
     )
     assert np.array_equal(
-        oscar_empty.num_output_per_event(), np.array([[0, 0], [1, 0]])
+        oscar_empty.num_output_per_event(), np.array([])
     )
     assert np.array_equal(
         oscar_charged_participants.num_output_per_event(),
         np.array([[0, 12], [1, 10]]),
     )
     assert np.array_equal(
-        oscar_uncharged_specators.num_output_per_event(),
-        np.array([[0, 0], [1, 10]]),
+        oscar_uncharged_spectators.num_output_per_event(),
+        np.array([[0, 10]]),
     )
-    del oscar_file, oscar_empty
+    assert np.array_equal(
+        oscar_empty_multiplicity.num_output_per_event(), np.array([])
+    )
+    del oscar_file, oscar_charged, oscar_uncharged, oscar_empty, oscar_uncharged_spectators, oscar_empty_multiplicity
 
     # Create a particle list to be loaded into the Oscar object
     oscar_file = str(tmp_path / "particle_lists.oscar")
@@ -672,7 +678,7 @@ def test_filter_in_oscar_constructor(tmp_path):
         oscar_spectators.num_output_per_event(), np.array([[0, 20], [1, 22]])
     )
     assert np.array_equal(
-        oscar_empty.num_output_per_event(), np.array([[0, 0], [1, 0]])
+        oscar_empty.num_output_per_event(), np.array([])
     )
     assert np.array_equal(
         oscar_spectators_strange.num_output_per_event(),
@@ -680,7 +686,7 @@ def test_filter_in_oscar_constructor(tmp_path):
     )
     assert np.array_equal(
         oscar_participants_strange.num_output_per_event(),
-        np.array([[0, 10], [1, 0]]),
+        np.array([[0, 10]]),
     )
 
 


### PR DESCRIPTION
Due to sloppy implementation in #296 by @LucasConstantin and an at least equally sloppy review by myself, there were unused variables which didn't handle the case of inverted cut boundaries. Upon fixing and testing this, I noticed that we do not handle correctly empty events when filtering, namely we do not remove them. The multiplicity cut event removal was not done for constructors, only for manual filtering afterwards. This opened Pandora's box.
In the current state of affairs, I keep events which are fed into the constructor empty, and only remove such which are emptied by filtering. In future, this should maybe be customisable.