### PR TITLE
Checkout merge commit and not the branch

### DIFF
--- a/.github/workflows/code_formatting.yml
+++ b/.github/workflows/code_formatting.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
       with:
-        ref: ${{ github.head_ref }}  # Check out the pull request branch
+        ref: ${{ github.sha }}  # Check out the exact commit of the merged PR
 
     - name: Set up Python
       uses: actions/setup-python@v2


### PR DESCRIPTION
This fixes the issue that the formatter action fails if the merged PR branch is deleted too early. Now it will checkout the exact commit, which is always available, even after deleting the branch.