### PR TITLE
Roch/fix requirements

### DIFF
--- a/.github/workflows/code_formatting.yml
+++ b/.github/workflows/code_formatting.yml
@@ -42,7 +42,11 @@ jobs:
 
     - name: Push changes
       run: |
-        git push origin ${{ github.head_ref }}
+        branch_to_push=${{ github.head_ref }}
+        if ! git ls-remote --exit-code origin "${branch_to_push}"; then
+          branch_to_push=${{ github.base_ref }}
+        fi
+        git push origin $branch_to_push
 
     - name: Run format test again
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "numpy>=1.23.5",
     "scipy>=1.10.1",
     "abc-property==1.0",
-    "fastjet==3.4.1.3",
+    "fastjet>=3.4.2.1",
     "matplotlib>=3.7.1"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,10 +27,9 @@ classifiers = [
 ]
 
 dependencies = [
-    "particle==0.23.0",
+    "particle>=0.23.0",
     "numpy>=1.23.5",
     "scipy>=1.10.1",
-    "abc-property==1.0",
     "fastjet>=3.4.2.1",
     "matplotlib>=3.7.1"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,11 @@ build-backend = "setuptools.build_meta"
 name = "sparkx"
 version = "2.0.0"
 authors = [
+    { name="Lucas Constantin", email="constantin@itp.uni-frankfurt.de"},
     { name="Niklas Götz", email="goetz@itp.uni-frankfurt.de"},
     { name="Renata Krupczak", email="rkrupczak@physik.uni-bielefeld.de"},
     { name="Hendrik Roch", email="hroch@wayne.edu" },
+    { name="Carl Rosenkvist", email="rosenkvist@itp.uni-frankfurt.de"},
     { name="Nils Sass", email="nsass@itp.uni-frankfurt.de" }
 ]
 description = "Software Package for Analyzing Relativistic Kinematics in Collision eXperiments"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
 # Main dependencies
-particle==0.23.0
+particle>=0.23.0
 numpy>=1.23.5
 scipy>=1.10.1
-abc-property==1.0
 fastjet>=3.4.2.1
 matplotlib>=3.7.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ particle==0.23.0
 numpy>=1.23.5
 scipy>=1.10.1
 abc-property==1.0
-fastjet==3.4.1.3
+fastjet>=3.4.2.1
 matplotlib>=3.7.1
 
 # Documentation dependencies
@@ -15,7 +15,7 @@ setuptools>=68.0.0
 
 # Development and testing dependencies
 pytest>=7.4.3
-black>=24.8.0
+black==24.8.0
 
 # Editable Sparkx install
 -e .

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,9 @@ setup(
     packages=find_packages(where='src'),
     package_dir={'': 'src'},
     install_requires=[
-        "particle==0.23.0",
+        "particle>=0.23.0",
         "numpy>=1.23.5",
         "scipy>=1.10.1",
-        "abc-property==1.0",
         "fastjet>=3.4.2.1",
         "matplotlib>=3.7.1",
     ],

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
         "numpy>=1.23.5",
         "scipy>=1.10.1",
         "abc-property==1.0",
-        "fastjet==3.4.1.3",
+        "fastjet>=3.4.2.1",
         "matplotlib>=3.7.1",
     ],
     version='2.0.0',

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     description='Software Package for Analyzing Relativistic Kinematics in Collision eXperiments',
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
-    author='Niklas Götz, Renata Krupczak, Hendrik Roch, Nils Sass',
+    author='Lucas Constantin, Niklas Götz, Renata Krupczak, Hendrik Roch, Carl Rosenkvist, Nils Sass',
     author_email="goetz@itp.uni-frankfurt.de, hroch@wayne.edu, nsass@itp.uni-frankfurt.de",
     url="https://smash-transport.github.io/sparkx/",
     download_url="https://github.com/smash-transport/sparkx",


### PR DESCRIPTION
This sets a lower limit for the fastjet version and fixes #318.
The version for the formatted package black is also fixed to ensure that our formatting always stays the same.

This also tries to fix the issue with the formatting in case the branch is deleted too fast. Then it's supposed to directly push to the devel or main (depending to which one the PR is).