### PR TITLE
Replace ASCIICustom by ASCII

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@
 </a>
 
 This package is designed to assist users of the [SMASH](https://smash-transport.github.io/) and [JETSCAPE/X-SCAPE](https://jetscape.org/) codes to analyze the output of the simulation data.
-It contains multiple classes to read in the simulation outputs in Oscar2013/Oscar2013Extended/Oscar2013Extended_IC/Oscar2013Extended_Photons/ASCIICustom format or the hadron/parton output of JETSCAPE/X-SCAPE.
+It contains multiple classes to read in the simulation outputs in Oscar2013/Oscar2013Extended/Oscar2013Extended_IC/Oscar2013Extended_Photons/ASCII format or the hadron/parton output of JETSCAPE/X-SCAPE.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -20,7 +20,7 @@ SPARKX
    </a>
 
 This package is designed to assist users of the `SMASH <https://smash-transport.github.io/>`_ and `JETSCAPE/X-SCAPE <https://jetscape.org/>`_ codes to analyze the output of the simulation data.
-It contains multiple classes to read in the simulation outputs in Oscar2013/Oscar2013Extended/Oscar2013Extended_IC/Oscar2013Extended_Photons/ASCIICustom format or the hadron/parton output of JETSCAPE/X-SCAPE.
+It contains multiple classes to read in the simulation outputs in Oscar2013/Oscar2013Extended/Oscar2013Extended_IC/Oscar2013Extended_Photons/ASCII format or the hadron/parton output of JETSCAPE/X-SCAPE.
 
 .. toctree::
    :maxdepth: 2

--- a/src/sparkx/Particle.py
+++ b/src/sparkx/Particle.py
@@ -256,7 +256,7 @@ class Particle:
 
         if attribute_list != [] and input_format != "ASCII":
             raise ValueError(
-                "'OscarCustom' format requires 'attribute_list' to be given."
+                "'ASCII' format requires 'attribute_list' to be given."
             )
 
         if (input_format is not None) and (particle_array is not None):
@@ -271,7 +271,7 @@ class Particle:
         attribute_list: List[str],
     ) -> None:
         """
-        Initialize instance attributes based on the provided input format and array, and optionally an atttribute list.
+        Initialize instance attributes based on the provided input format and array, and optionally an attribute list.
 
         Parameters
         ----------


### PR DESCRIPTION
There were a few `ASCIICustom` strings in the code base. I replaced them with `ASCII`.
This closes #346 