### PR TITLE
Fix normalization in midrapidity BulkObservables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ The main categories for changes in this file are:
 
 A `Deprecated` section could be added if needed for soon-to-be removed features.
 
+## v2.1.1-Chatelet
+Date: 2025-XX-XX
+
+### Fixed
+* BulkObservables: Fix bug in the calculation of the integrated yields, mean transverse momentum and mass at midrapidity.
+
+[Link to diff from previous version](https://github.com/smash-transport/sparkx/compare/v2.1.0...v2.1.1)
+
 ## v2.1.0-Chatelet
 Date: 2025-06-19
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -21,7 +21,7 @@ sys.path.insert(0, os.path.abspath('../../src/sparkx/loader'))
 project = 'sparkx'
 copyright = '2025, SPARKX Collaboration'
 author = 'Nils Sass, Hendrik Roch, Niklas Götz, Renata Krupczak, Lucas Constantin'
-release = '2.1.0'
+release = '2.1.1'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sparkx"
-version = "2.1.0"
+version = "2.1.1"
 authors = [
     { name="Nils Sass", email="nsass@itp.uni-frankfurt.de" },
     { name="Hendrik Roch", email="hroch@wayne.edu" },

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
         "fastjet>=3.4.2.1",
         "matplotlib>=3.7.1",
     ],
-    version='2.1.0',
+    version='2.1.1',
     description='Software Package for Analyzing Relativistic Kinematics in Collision eXperiments',
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",

--- a/src/sparkx/BulkObservables.py
+++ b/src/sparkx/BulkObservables.py
@@ -348,14 +348,15 @@ class BulkObservables:
         else:
             return self._differential_yield("mT", bin_properties)
 
-    def _compute_mid_rapidity(
+    def _compute_mid_rapidity_per_event(
         self,
         y_width: float,
         quantity: str,
         property_func: Callable[[Particle], float],
-    ) -> float:
+    ) -> list[float]:
         """
-        Generalized function to compute mid-rapidity yields and averages.
+        Generalized function to compute mid-rapidity averages
+        for each event.
 
         Parameters
         ----------
@@ -363,24 +364,20 @@ class BulkObservables:
             The rapidity window width, centered at 0.
         quantity : str
             The rapidity-related method name (rapidity, pseudorapidity, etc.).
-        property_func : callable, optional
+        property_func : callable
             Function to apply to each selected particle.
-            If None, counts particles instead.
 
         Returns
         -------
-        float
-            Event-averaged particle yield or mean property.
+        list
+            List of mean values for each event.
         """
         if not isinstance(y_width, (int, float)):
             raise TypeError("y_width must be of type int or float")
-
         if y_width <= 0:
             raise ValueError("y_width must be a positive number.")
-
-        num_events = len(self.particle_objects)
-        if num_events == 0:
-            return 0
+        if not self.particle_objects:
+            return []
 
         particle_method = getattr(self.particle_objects[0][0], quantity)
         if not callable(particle_method):
@@ -388,26 +385,105 @@ class BulkObservables:
                 f"'{quantity}' is not a callable method of Particle"
             )
 
-        value = 0.0
+        event_means = []
+        half_width = y_width / 2
         for event in self.particle_objects:
-            for particle in event:
-                if -y_width / 2 <= getattr(particle, quantity)() <= y_width / 2:
-                    value += property_func(particle)
-        return value / num_events
+            selected_values = [
+                property_func(particle)
+                for particle in event
+                if -half_width <= particle_method() <= half_width
+            ]
+            if selected_values:
+                mean_value = sum(selected_values) / len(selected_values)
+                event_means.append(mean_value)
+            # else: skip events without particles in the window
+
+        return event_means
 
     def mid_rapidity_yield(
-        self, y_width: float = 1.0, quantity: str = "rapidity"
+        self,
+        y_width: float = 1.0,
+        quantity: str = "rapidity",
+        divide_by_width: bool = False,
     ) -> float:
-        return self._compute_mid_rapidity(y_width, quantity, lambda p: 1.0)
+        """
+        Calculate the event-averaged particle yield at mid-rapidity.
+
+        Parameters
+        ----------
+        y_width : float
+            The rapidity window width, centered at 0.
+        quantity : str
+            The rapidity-related method name (rapidity, pseudorapidity, etc.).
+        divide_by_width : bool
+            If True, return the estimated dN/dy by dividing by y_width.
+
+        Returns
+        -------
+        float
+            The event-averaged particle yield at mid-rapidity.
+        """
+        num_events = len(self.particle_objects)
+        if num_events == 0:
+            return 0.0
+
+        half_width = y_width / 2
+        total_selected = 0
+        for event in self.particle_objects:
+            count = sum(
+                1
+                for particle in event
+                if -half_width <= getattr(particle, quantity)() <= half_width
+            )
+            total_selected += count
+
+        mean_count = total_selected / num_events
+        return mean_count / y_width if divide_by_width else mean_count
 
     def mid_rapidity_mean_pT(
         self, y_width: float = 1.0, quantity: str = "rapidity"
     ) -> float:
-        return self._compute_mid_rapidity(
+        """
+        Compute event-wise mean pT, then average over events that have at least
+        one particle in mid-rapidity window.
+
+        Parameters
+        ----------
+        y_width : float
+            The rapidity window width, centered at 0.
+        quantity : str
+            The rapidity-related method name (rapidity, pseudorapidity, etc.).
+
+        Returns
+        -------
+        float
+            The event-averaged mean transverse momentum pT at mid-rapidity.
+        """
+        event_means = self._compute_mid_rapidity_per_event(
             y_width, quantity, lambda p: p.pT_abs()
         )
+        return sum(event_means) / len(event_means) if event_means else 0.0
 
     def mid_rapidity_mean_mT(
         self, y_width: float = 1.0, quantity: str = "rapidity"
     ) -> float:
-        return self._compute_mid_rapidity(y_width, quantity, lambda p: p.mT())
+        """
+        Compute event-wise mean mT, then average over events that have at least
+        one particle in mid-rapidity window.
+
+        Parameters
+        ----------
+        y_width : float
+            The rapidity window width, centered at 0.
+        quantity : str
+            The rapidity-related method name (rapidity, pseudorapidity, etc.).
+
+        Returns
+        -------
+        float
+            The event-averaged mean transverse mass mT at mid-rapidity.
+        """
+        event_means = self._compute_mid_rapidity_per_event(
+            y_width, quantity, lambda p: p.mT()
+        )
+        return sum(event_means) / len(event_means) if event_means else 0.0

--- a/tests/test_BulkObservables.py
+++ b/tests/test_BulkObservables.py
@@ -255,13 +255,13 @@ def test_dNdmT():
 def test_midrapidity():
     particles_list_single_event = []
 
-    for i in range(30):
+    for _ in range(30):
         p = Particle()
         p.E = 1
         p.pz = 0.2
 
         particles_list_single_event.append(p)
-    for i in range(30):
+    for _ in range(30):
         p = Particle()
         p.E = 1
         p.pz = 1
@@ -276,3 +276,60 @@ def test_midrapidity():
 
     # Check that 30 particles are at midrapidity
     assert dNdy_0 == 30
+
+
+def test_midrapidity_yield_with_width():
+    particles_list_single_event = []
+    for _ in range(30):
+        p = Particle()
+        p.E = 1
+        p.pz = 0.2
+
+        particles_list_single_event.append(p)
+
+    for _ in range(30):
+        p = Particle()
+        p.E = 1
+        p.pz = 1
+
+        particles_list_single_event.append(p)
+
+    particle_objects_list = [particles_list_single_event]
+    bulk_obs = BulkObservables(particle_objects_list)
+
+    dNdy_1 = bulk_obs.mid_rapidity_yield(y_width=2.0, divide_by_width=True)
+    # Check that 30 particles are at midrapidity, divided by width for dN/dy
+    assert dNdy_1 == 30 / 2.0
+
+
+def test_midrapidity_mean_pT():
+    particles_list_single_event = []
+    for _ in range(30):
+        p = Particle()
+        p.E = 1
+        p.pz = 0.2
+        p.px = 0.1
+        p.py = 0.1
+
+        particles_list_single_event.append(p)
+
+    for _ in range(30):
+        p = Particle()
+        p.E = 1
+        p.pz = 0.8
+        p.px = 0.1
+        p.py = 0.1
+
+        particles_list_single_event.append(p)
+
+    particle_objects_list = [particles_list_single_event]
+
+    # Create the BulkObservables object and call midrapidity_mean_pT
+    bulk_obs = BulkObservables(particle_objects_list)
+    mean_pT_0 = bulk_obs.mid_rapidity_mean_pT()
+
+    # expected mean pT is sqrt(0.1^2 + 0.1^2) / 1
+    expected_mean_pT = np.sqrt(0.1**2 + 0.1**2) / 1.0
+
+    # Check that the mean pT is correct
+    assert mean_pT_0 == pytest.approx(expected_mean_pT, rel=1e-6)


### PR DESCRIPTION
This fixes issue #380, where the mean transverse momentum and the mean transverse mass were reported to be off by orders of magnitude. This was due to a wrong normalization for the two quantities. They were averaged over events, but the quantity should be averaged for each event, e.g., $\langle\left[ p_{\rm T}\right]_{\rm particles}\rangle_{\rm events}$.

The new version does this double average and also implements the option to compute $dN/dy$ if wanted for the yield at midrapidity.
There are also unit tests added.

I have also updated the version numbers. If everything is fine with this PR, then we can have a bug fix release.